### PR TITLE
Make despawning on system finish optional

### DIFF
--- a/src/systems.rs
+++ b/src/systems.rs
@@ -70,7 +70,11 @@ pub fn partcle_spawner(
                 burst_index.0 = 0;
             } else {
                 if particle_count.0 == 0 {
-                    commands.entity(entity).despawn();
+                    if particle_system.despawn_on_finish {
+                        commands.entity(entity).despawn();
+                    } else {
+                        commands.entity(entity).remove::<Playing>();
+                    }
                 }
                 continue;
             }


### PR DESCRIPTION
**Changes**
- Adds the `despawn_on_finish` field to `ParticleSystem`, which defaults to `false`.
- Only calls `despawn()` on the entity if the `despawn_on_finish` parameter is true, otherwise, simply removes the `Playing` component.

