### PR TITLE
Set particle scale and color correctly on spawn

### DIFF
--- a/src/systems.rs
+++ b/src/systems.rs
@@ -151,6 +151,10 @@ pub fn partcle_spawner(
                             ..ParticleBundle::default()
                         })
                         .insert_bundle(SpriteBundle {
+                            sprite: Sprite {
+                                color: particle_system.color.at_lifetime_pct(0.0),
+                                ..Sprite::default()
+                            },
                             transform: spawn_point,
                             texture: particle_system.default_sprite.clone(),
                             ..SpriteBundle::default()
@@ -174,6 +178,10 @@ pub fn partcle_spawner(
                                 ..ParticleBundle::default()
                             })
                             .insert_bundle(SpriteBundle {
+                                sprite: Sprite {
+                                    color: particle_system.color.at_lifetime_pct(0.0),
+                                    ..Sprite::default()
+                                },
                                 transform: spawn_point,
                                 texture: particle_system.default_sprite.clone(),
                                 ..SpriteBundle::default()

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -130,6 +130,8 @@ pub fn partcle_spawner(
                 .z_value_override
                 .as_ref()
                 .map_or(0.0, |jittered_value| jittered_value.get_value(&mut rng));
+            let particle_scale = particle_system.scale.at_lifetime_pct(0.0);
+            spawn_point.scale = Vec3::new(particle_scale, particle_scale, particle_scale);
 
             match particle_system.space {
                 ParticleSpace::World => {


### PR DESCRIPTION
## Problem

If the base sprite does not start with the initial scale and color that matches the system, particles may flash one frame of the full sized / incorrectly colored sprite before being corrected.

The modifier systems for particles do not run until the frame after spawn and these parameters are not correctly set during spawning.

## Solution
Set the sprite color and scale based on the particle system values at the initial (`0.0`) lifetime.