### PR TITLE
Center emitter shape on the angle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+.DS_Store

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -122,7 +122,7 @@ pub fn partcle_spawner(
                     .with_rotation(global_transform.rotation)
                     .with_scale(global_transform.scale),
             };
-            let radian: f32 = rng.gen_range(0.0..1.0) * particle_system.emitter_shape
+            let radian: f32 = rng.gen_range(-0.5..0.5) * particle_system.emitter_shape
                 + particle_system.emitter_angle;
             let direction = Vec3::new(radian.cos(), radian.sin(), 0.0);
 


### PR DESCRIPTION
Previously the emitter shape range was emitting particles in [`emitter_shape`, `emitter_shape`+`emitter_angle`] range. Causing one edge of the cone to be at the emitter angle.

Instead, we should make the emitter angle be the center of the cone.