### PR TITLE
Correctly handle spawn rate of zero

### DIFF
--- a/src/systems.rs
+++ b/src/systems.rs
@@ -87,9 +87,9 @@ pub fn partcle_spawner(
 
         let pct = running_state.running_time / particle_system.system_duration_seconds;
         let remaining_particles = (particle_system.max_particles - particle_count.0) as f32;
-
+        let current_spawn_rate = particle_system.spawn_rate_per_second.at_lifetime_pct(pct);
         let mut to_spawn = ((running_state.running_time - running_state.running_time.floor())
-            * particle_system.spawn_rate_per_second.at_lifetime_pct(pct)
+            * current_spawn_rate
             - running_state.spawned_this_second as f32)
             .floor()
             .min(remaining_particles)
@@ -107,6 +107,7 @@ pub fn partcle_spawner(
         if to_spawn == 0
             && running_state.spawned_this_second == 0
             && particle_count.0 < particle_system.max_particles
+            && current_spawn_rate > 0.0
         {
             to_spawn = 1;
         }


### PR DESCRIPTION
**Problem**
Currently when the spawn rate is zero, a particle system spawner will still spawn 1 particle per second.

**Solution**
Check the spawn rate being zero before doing the spawn count adjustment.
