### PR TITLE
Upgrade bevy 0.9

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  RUST_VERSION: 1.62.0
+  RUST_VERSION: 1.65.0
 
 jobs:
   test:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bevy_particle_systems"
 version = "0.5.0"
 edition = "2021"
-rust-version = "1.59"
+rust-version = "1.65"
 authors = ["Abnormal Brain Studios"]
 license = "MIT"
 description = "A particle system plugin for Bevy"
@@ -11,16 +11,16 @@ keywords = ["game", "gamedev", "bevy"]
 categories = ["game-development"]
 
 [dependencies]
-bevy_app = "0.8"
-bevy_asset = "0.8"
-bevy_ecs = "0.8"
-bevy_hierarchy = "0.8"
-bevy_math = "0.8"
-bevy_render = "0.8"
-bevy_sprite = "0.8"
-bevy_time = "0.8"
-bevy_transform = "0.8"
+bevy_app = "0.9"
+bevy_asset = "0.9"
+bevy_ecs = "0.9"
+bevy_hierarchy = "0.9"
+bevy_math = "0.9"
+bevy_render = "0.9"
+bevy_sprite = "0.9"
+bevy_time = "0.9"
+bevy_transform = "0.9"
 rand = "0.8"
 
 [dev-dependencies]
-bevy = { version = "0.8", default-features=false, features = ["bevy_asset", "render", "png", "bevy_winit", "x11"] }
+bevy = { version = "0.9", default-features=false, features = ["bevy_asset", "render", "png", "bevy_winit", "x11"] }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,9 +1,10 @@
 use bevy::{
     diagnostic::{EntityCountDiagnosticsPlugin, FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
     prelude::{App, Camera2dBundle, ClearColor, Color, Commands, Res},
-    window::{PresentMode, WindowDescriptor},
+    window::{PresentMode, WindowDescriptor, WindowPlugin},
     DefaultPlugins,
 };
+use bevy_app::PluginGroup;
 use bevy_asset::AssetServer;
 use bevy_particle_systems::{
     ColorOverTime, ColorPoint, Gradient, JitteredValue, ParticleBurst, ParticleSystem,
@@ -13,24 +14,26 @@ use bevy_particle_systems::{
 fn main() {
     App::new()
         .insert_resource(ClearColor(Color::BLACK))
-        .insert_resource(WindowDescriptor {
-            present_mode: PresentMode::Immediate,
-            ..WindowDescriptor::default()
-        })
         .add_plugin(EntityCountDiagnosticsPlugin)
         .add_plugin(FrameTimeDiagnosticsPlugin::default())
         .add_plugin(LogDiagnosticsPlugin::default())
-        .add_plugins(DefaultPlugins)
+        .add_plugins(DefaultPlugins.set(WindowPlugin {
+            window: WindowDescriptor {
+                present_mode: PresentMode::AutoNoVsync,
+                ..Default::default()
+            },
+            ..Default::default()
+        }))
         .add_plugin(ParticleSystemPlugin::default()) // <-- Add the plugin
         .add_startup_system(startup_system)
         .run();
 }
 
 fn startup_system(mut commands: Commands, asset_server: Res<AssetServer>) {
-    commands.spawn_bundle(Camera2dBundle::default());
+    commands.spawn(Camera2dBundle::default());
 
     commands
-        .spawn_bundle(ParticleSystemBundle {
+        .spawn(ParticleSystemBundle {
             particle_system: ParticleSystem {
                 max_particles: 50_000,
                 default_sprite: asset_server.load("px.png"),

--- a/examples/local_space.rs
+++ b/examples/local_space.rs
@@ -32,10 +32,10 @@ fn main() {
 }
 
 fn startup_system(mut commands: Commands, asset_server: Res<AssetServer>) {
-    commands.spawn_bundle(Camera2dBundle::default());
+    commands.spawn(Camera2dBundle::default());
 
     commands
-        .spawn_bundle(ParticleSystemBundle {
+        .spawn(ParticleSystemBundle {
             particle_system: ParticleSystem {
                 max_particles: 500,
                 emitter_shape: std::f32::consts::PI * 0.25,
@@ -62,7 +62,7 @@ fn startup_system(mut commands: Commands, asset_server: Res<AssetServer>) {
         .insert(Circler::new(Vec3::new(50.0, 0.0, 0.0), 50.0));
 
     commands
-        .spawn_bundle(ParticleSystemBundle {
+        .spawn(ParticleSystemBundle {
             particle_system: ParticleSystem {
                 max_particles: 500,
                 emitter_shape: std::f32::consts::PI * 0.25,
@@ -105,7 +105,7 @@ pub fn circler(
     time: Res<Time>,
     mut particle_system_query: Query<(&Circler, &mut Transform), With<ParticleSystem>>,
 ) {
-    let rad = time.seconds_since_startup() as f32;
+    let rad = time.elapsed_seconds() as f32;
     let quat = Quat::from_rotation_z(rad).normalize();
     let dir = quat * Vec3::Y;
     for (circler, mut transform) in &mut particle_system_query {

--- a/examples/time_scaling.rs
+++ b/examples/time_scaling.rs
@@ -11,23 +11,23 @@ use bevy::{
 use bevy_asset::AssetServer;
 use bevy_particle_systems::{
     ColorOverTime, ColorPoint, Gradient, JitteredValue, ParticleSpace, ParticleSystem,
-    ParticleSystemBundle, ParticleSystemPlugin, Playing, TimeScale,
+    ParticleSystemBundle, ParticleSystemPlugin, Playing,
 };
+use bevy_time::Time;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_plugin(ParticleSystemPlugin::default()) // <-- Add the plugin
         .add_startup_system(startup_system)
-        .insert_resource(Some(TimeScale::default()))
         .add_system(time_scale_changer)
         .run();
 }
 
 fn startup_system(mut commands: Commands, asset_server: Res<AssetServer>) {
-    commands.spawn_bundle(Camera2dBundle::default());
+    commands.spawn(Camera2dBundle::default());
 
     commands
-        .spawn_bundle(ParticleSystemBundle {
+        .spawn(ParticleSystemBundle {
             particle_system: ParticleSystem {
                 max_particles: 500,
                 emitter_shape: std::f32::consts::PI * 0.25,
@@ -54,7 +54,7 @@ fn startup_system(mut commands: Commands, asset_server: Res<AssetServer>) {
         .insert(Playing);
 
     commands
-        .spawn_bundle(ParticleSystemBundle {
+        .spawn(ParticleSystemBundle {
             particle_system: ParticleSystem {
                 max_particles: 500,
                 emitter_shape: std::f32::consts::PI * 0.25,
@@ -80,15 +80,15 @@ fn startup_system(mut commands: Commands, asset_server: Res<AssetServer>) {
         .insert(Playing);
 }
 
-fn time_scale_changer(keys: Res<Input<KeyCode>>, mut time_scale: ResMut<Option<TimeScale>>) {
+fn time_scale_changer(keys: Res<Input<KeyCode>>, mut time: ResMut<Time>) {
     for key_code in keys.get_just_pressed() {
         match key_code {
-            KeyCode::Key1 => *time_scale = Some(TimeScale(1.0)),
-            KeyCode::Key2 => *time_scale = Some(TimeScale(2.0)),
-            KeyCode::Key3 => *time_scale = Some(TimeScale(4.0)),
-            KeyCode::Key4 => *time_scale = Some(TimeScale(8.0)),
-            KeyCode::Key5 => *time_scale = Some(TimeScale(10.0)),
-            KeyCode::Key0 => *time_scale = Some(TimeScale(0.0)),
+            KeyCode::Key1 => time.set_relative_speed(1.0),
+            KeyCode::Key2 => time.set_relative_speed(2.0),
+            KeyCode::Key3 => time.set_relative_speed(4.0),
+            KeyCode::Key4 => time.set_relative_speed(8.0),
+            KeyCode::Key5 => time.set_relative_speed(10.0),
+            KeyCode::Key0 => time.set_relative_speed(0.0),
             _ => {}
         }
     }

--- a/src/components.rs
+++ b/src/components.rs
@@ -291,28 +291,14 @@ pub struct ParticleSystemBundle {
     pub burst_index: BurstIndex,
 
     /// Required for child particles to be visible when running in Local space.
-    #[bundle]
     pub visibility: VisibilityBundle,
 }
 
-#[derive(Debug, Bundle, Default)]
+#[derive(Debug, Default, Bundle)]
 pub(crate) struct ParticleBundle {
     pub particle: Particle,
     pub lifetime: Lifetime,
     pub velocity: Velocity,
     pub direction: Direction,
     pub distance: DistanceTraveled,
-}
-
-/// Specifies the time scaling for all particle systems.
-///
-/// This can be used to speed up the particle system if the speed of time of the game changes.
-/// The contained value is used as a multiplier for the frame delta time.
-#[derive(Debug, Clone, Copy)]
-pub struct TimeScale(pub f32);
-
-impl Default for TimeScale {
-    fn default() -> Self {
-        Self(1.0)
-    }
 }

--- a/src/components.rs
+++ b/src/components.rs
@@ -126,7 +126,7 @@ pub struct ParticleSystem {
     /// What coordinate space particles should use.
     pub space: ParticleSpace,
 
-    /// Dictates whether this system respects Bevy's global time scaling by using [`Time::delta_seconds`] when true, or [`Time::raw_delta_seconds`] when false.
+    /// Dictates whether this system respects Bevy's global time scaling by using [`bevy_time::Time::delta_seconds`] when true, or [`bevy_time::Time::raw_delta_seconds`] when false.
     pub use_scaled_time: bool,
 
     /// Indicates that the entity the [`ParticleSystem`] is on should be despawned when the system completes and has no more particles.

--- a/src/components.rs
+++ b/src/components.rs
@@ -126,7 +126,7 @@ pub struct ParticleSystem {
     /// What coordinate space particles should use.
     pub space: ParticleSpace,
 
-    /// `true` indicates that the system will use scaled time if it is present, `false` will result in always using real time.
+    /// Dictates whether this system respects Bevy's global time scaling by using [`Time::delta_seconds`] when true, or [`Time::raw_delta_seconds`] when false.
     pub use_scaled_time: bool,
 
     /// Indicates that the entity the [`ParticleSystem`] is on should be despawned when the system completes and has no more particles.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,6 @@ impl Plugin for ParticleSystemPlugin {
             .add_system(particle_lifetime)
             .add_system(particle_color)
             .add_system(particle_transform)
-            .add_system(particle_cleanup)
-            .init_resource::<Option<TimeScale>>();
+            .add_system(particle_cleanup);
     }
 }


### PR DESCRIPTION
Changes:
- Updates dependencies to Bevy `0.9`
- Removes `TimeScale` in favor of Bevy's global time scaling.
- Updates required rust version to `1.65.0` as Bevy does not work otherwise.
- Use `spawn` instead of `spawn_bundle`
- Compatibility tweaks to examples and docs.

Closes #12 

Thanks to @LarsDu for their previous attempt at this upgrade while it was still in dev and mapping out most of the necessary changes!