### PR TITLE
Add bevy_reflect support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,6 @@ repository = "https://github.com/abnormalbrain/bevy_particle_systems"
 keywords = ["game", "gamedev", "bevy"]
 categories = ["game-development"]
 
-[features]
-default = ["bevy_reflect"]
-bevy_reflect = ["dep:bevy_reflect"]
-
 [dependencies]
 bevy_app = "0.9"
 bevy_asset = "0.9"
@@ -24,7 +20,7 @@ bevy_render = "0.9"
 bevy_sprite = "0.9"
 bevy_time = "0.9"
 bevy_transform = "0.9"
-bevy_reflect = { version = "0.9", optional = true }
+bevy_reflect = "0.9"
 rand = "0.8"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,10 @@ repository = "https://github.com/abnormalbrain/bevy_particle_systems"
 keywords = ["game", "gamedev", "bevy"]
 categories = ["game-development"]
 
+[features]
+default = ["bevy_reflect"]
+bevy_reflect = ["dep:bevy_reflect"]
+
 [dependencies]
 bevy_app = "0.9"
 bevy_asset = "0.9"
@@ -20,6 +24,7 @@ bevy_render = "0.9"
 bevy_sprite = "0.9"
 bevy_time = "0.9"
 bevy_transform = "0.9"
+bevy_reflect = { version = "0.9", optional = true }
 rand = "0.8"
 
 [dev-dependencies]

--- a/src/components.rs
+++ b/src/components.rs
@@ -232,7 +232,8 @@ impl Direction {
 pub struct Playing;
 
 /// Tracks running state of the [`ParticleSystem`] on the same entity.
-#[derive(Debug, Component, Default)]
+#[derive(Debug, Component, Default, Reflect)]
+#[reflect(Component)]
 pub struct RunningState {
     /// Tracks the current amount of time since the start of the system.
     ///
@@ -249,11 +250,13 @@ pub struct RunningState {
 }
 
 /// Tracks the current particle count for the [`ParticleSystem`] on the same entity.
-#[derive(Debug, Component, Default)]
+#[derive(Debug, Component, Default, Reflect)]
+#[reflect(Component)]
 pub struct ParticleCount(pub usize);
 
 /// Tracks the current index for particle bursts for the [`ParticleSystem`] on the same entity.
-#[derive(Debug, Component, Default)]
+#[derive(Debug, Component, Default, Reflect)]
+#[reflect(Component)]
 pub struct BurstIndex(pub usize);
 
 /// A spawnable bundle for a [`ParticleSystem`] containing all of the necessary components.

--- a/src/components.rs
+++ b/src/components.rs
@@ -1,8 +1,12 @@
 //! Defines bevy Components used by the particle system.
 
 use bevy_asset::Handle;
+#[cfg(feature = "bevy_reflect")]
+use bevy_ecs::prelude::ReflectComponent;
 use bevy_ecs::prelude::{Bundle, Component, Entity};
 use bevy_math::Vec3;
+#[cfg(feature = "bevy_reflect")]
+use bevy_reflect::prelude::*;
 use bevy_render::prelude::{Image, VisibilityBundle};
 use bevy_transform::prelude::{GlobalTransform, Transform};
 
@@ -12,6 +16,7 @@ use crate::values::{ColorOverTime, JitteredValue, ValueOverTime};
 ///
 /// Bursts do not count as part of the per-second spawn rate.
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect, FromReflect))]
 pub struct ParticleBurst {
     /// The time during the life cycle of a system that the burst should occur.
     ///
@@ -35,6 +40,7 @@ impl ParticleBurst {
 
 /// Defines what space a particle should operate in.
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect, FromReflect))]
 pub enum ParticleSpace {
     /// Indicates particles should move relative to a parent.
     Local,
@@ -50,6 +56,8 @@ pub enum ParticleSpace {
 /// If a [`ParticleSystem`] component is removed before all particles have finished their lifetime, the associated particles will all despawn themselves
 /// on the next frame.
 #[derive(Debug, Component, Clone)]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
+#[cfg_attr(feature = "bevy_reflect", reflect(Component))]
 pub struct ParticleSystem {
     /// The maximum number of particles the system can have alive at any given time.
     pub max_particles: usize,

--- a/src/components.rs
+++ b/src/components.rs
@@ -1,11 +1,8 @@
 //! Defines bevy Components used by the particle system.
 
 use bevy_asset::Handle;
-#[cfg(feature = "bevy_reflect")]
-use bevy_ecs::prelude::ReflectComponent;
-use bevy_ecs::prelude::{Bundle, Component, Entity};
+use bevy_ecs::prelude::{Bundle, Component, Entity, ReflectComponent};
 use bevy_math::Vec3;
-#[cfg(feature = "bevy_reflect")]
 use bevy_reflect::prelude::*;
 use bevy_render::prelude::{Image, VisibilityBundle};
 use bevy_transform::prelude::{GlobalTransform, Transform};
@@ -15,8 +12,7 @@ use crate::values::{ColorOverTime, JitteredValue, ValueOverTime};
 /// Defines a burst of a specified number of particles at the given time in a running particle system.
 ///
 /// Bursts do not count as part of the per-second spawn rate.
-#[derive(Debug, Clone, Copy)]
-#[cfg_attr(feature = "bevy_reflect", derive(Reflect, FromReflect))]
+#[derive(Debug, Clone, Copy, Reflect, FromReflect)]
 pub struct ParticleBurst {
     /// The time during the life cycle of a system that the burst should occur.
     ///
@@ -39,8 +35,7 @@ impl ParticleBurst {
 }
 
 /// Defines what space a particle should operate in.
-#[derive(Debug, Clone, Copy)]
-#[cfg_attr(feature = "bevy_reflect", derive(Reflect, FromReflect))]
+#[derive(Debug, Clone, Copy, Reflect, FromReflect)]
 pub enum ParticleSpace {
     /// Indicates particles should move relative to a parent.
     Local,
@@ -55,9 +50,8 @@ pub enum ParticleSpace {
 ///
 /// If a [`ParticleSystem`] component is removed before all particles have finished their lifetime, the associated particles will all despawn themselves
 /// on the next frame.
-#[derive(Debug, Component, Clone)]
-#[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
-#[cfg_attr(feature = "bevy_reflect", reflect(Component))]
+#[derive(Debug, Component, Clone, Reflect)]
+#[reflect(Component)]
 pub struct ParticleSystem {
     /// The maximum number of particles the system can have alive at any given time.
     pub max_particles: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,9 +95,10 @@ impl Plugin for ParticleSystemPlugin {
             .add_system(particle_lifetime)
             .add_system(particle_color)
             .add_system(particle_transform)
-            .add_system(particle_cleanup);
-
-        #[cfg(feature = "bevy_reflect")]
-        app.register_type::<ParticleSystem>();
+            .add_system(particle_cleanup)
+            .register_type::<ParticleSystem>()
+            .register_type::<ParticleCount>()
+            .register_type::<RunningState>()
+            .register_type::<BurstIndex>();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,5 +96,8 @@ impl Plugin for ParticleSystemPlugin {
             .add_system(particle_color)
             .add_system(particle_transform)
             .add_system(particle_cleanup);
+
+        #[cfg(feature = "bevy_reflect")]
+        app.register_type::<ParticleSystem>();
     }
 }

--- a/src/values.rs
+++ b/src/values.rs
@@ -1,11 +1,9 @@
 //! Different value types and controls used in particle systems.
 use std::ops::Range;
 
+use bevy_reflect::{FromReflect, Reflect};
 use bevy_render::prelude::Color;
 use rand::{prelude::ThreadRng, Rng};
-
-#[cfg(feature = "bevy_reflect")]
-use bevy_reflect::prelude::*;
 
 /// A value that has random jitter within a configured range added to it when read.
 ///
@@ -39,8 +37,7 @@ use bevy_reflect::prelude::*;
 ///     assert!(value >= 5.0);
 /// }
 /// ```
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "bevy_reflect", derive(Reflect, FromReflect))]
+#[derive(Debug, Clone, Reflect, FromReflect)]
 pub struct JitteredValue {
     /// The base value that specified jitter will be added to.
     pub value: f32,
@@ -167,8 +164,7 @@ impl RoughlyEqual<f64> for f64 {
 /// Defines a color at a specific point in a gradient.
 ///
 /// ``point`` should be between `0.0` and `1.0` inclusive.
-#[derive(Debug, Clone, Copy)]
-#[cfg_attr(feature = "bevy_reflect", derive(Reflect, FromReflect))]
+#[derive(Debug, Clone, Copy, Reflect, FromReflect)]
 pub struct ColorPoint {
     /// Defines the [`Color`] value at a specified point in time.
     pub color: Color,
@@ -207,8 +203,7 @@ impl ColorPoint {
 /// let alpha_gradient = Gradient::new(vec![ColorPoint::new(Color::rgba(1.0, 1.0, 1.0, 1.0), 0.0), ColorPoint::new(Color::rgba(1.0, 1.0, 1.0, 0.0), 1.0)]);
 /// assert_eq!(alpha_gradient.get_color(0.5), Color::rgba(1.0, 1.0, 1.0, 0.5));
 /// ```
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "bevy_reflect", derive(Reflect, FromReflect))]
+#[derive(Debug, Clone, Reflect, FromReflect)]
 pub struct Gradient(Vec<ColorPoint>);
 
 impl Gradient {
@@ -295,8 +290,7 @@ impl Gradient {
 /// Defines how a color changes over time
 ///
 /// Colors can either be constant, or follow a [`crate::values::Gradient`].
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
+#[derive(Debug, Clone, Reflect)]
 pub enum ColorOverTime {
     /// Specifies that a color should remain a constant color over time.
     Constant(Color),
@@ -357,8 +351,7 @@ impl ColorOverTime {
 /// assert!(s.at_lifetime_pct(0.5).roughly_equal(0.0));
 /// assert!(s.at_lifetime_pct(0.75).roughly_equal(-1.0));
 /// ```
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
+#[derive(Debug, Clone, Reflect)]
 pub enum ValueOverTime {
     /// Specifies the value should be linearly interpolated between two values over time.
     Lerp(Lerp),
@@ -399,8 +392,7 @@ impl ValueOverTime {
 }
 
 /// Defines a value that will linearly move between ``a`` and ``b`` over its configured lifetime.
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "bevy_reflect", derive(Reflect, FromReflect))]
+#[derive(Debug, Clone, Reflect, FromReflect)]
 pub struct Lerp {
     /// The starting value, returned when ``pct`` is `0.0`.
     pub a: f32,
@@ -422,8 +414,7 @@ impl Default for Lerp {
 }
 
 /// Defines a value that will move in a sinusoidal wave pattern over it's configured lifetime.
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "bevy_reflect", derive(Reflect, FromReflect))]
+#[derive(Debug, Clone, Reflect, FromReflect)]
 pub struct SinWave {
     /// The amplitude of the wave as time progresses.
     ///

--- a/src/values.rs
+++ b/src/values.rs
@@ -4,6 +4,9 @@ use std::ops::Range;
 use bevy_render::prelude::Color;
 use rand::{prelude::ThreadRng, Rng};
 
+#[cfg(feature = "bevy_reflect")]
+use bevy_reflect::prelude::*;
+
 /// A value that has random jitter within a configured range added to it when read.
 ///
 /// Ranges can include negative values as well to return values below the specified base value.
@@ -37,6 +40,7 @@ use rand::{prelude::ThreadRng, Rng};
 /// }
 /// ```
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect, FromReflect))]
 pub struct JitteredValue {
     /// The base value that specified jitter will be added to.
     pub value: f32,
@@ -164,6 +168,7 @@ impl RoughlyEqual<f64> for f64 {
 ///
 /// ``point`` should be between `0.0` and `1.0` inclusive.
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect, FromReflect))]
 pub struct ColorPoint {
     /// Defines the [`Color`] value at a specified point in time.
     pub color: Color,
@@ -203,6 +208,7 @@ impl ColorPoint {
 /// assert_eq!(alpha_gradient.get_color(0.5), Color::rgba(1.0, 1.0, 1.0, 0.5));
 /// ```
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect, FromReflect))]
 pub struct Gradient(Vec<ColorPoint>);
 
 impl Gradient {
@@ -290,6 +296,7 @@ impl Gradient {
 ///
 /// Colors can either be constant, or follow a [`crate::values::Gradient`].
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
 pub enum ColorOverTime {
     /// Specifies that a color should remain a constant color over time.
     Constant(Color),
@@ -351,6 +358,7 @@ impl ColorOverTime {
 /// assert!(s.at_lifetime_pct(0.75).roughly_equal(-1.0));
 /// ```
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
 pub enum ValueOverTime {
     /// Specifies the value should be linearly interpolated between two values over time.
     Lerp(Lerp),
@@ -392,6 +400,7 @@ impl ValueOverTime {
 
 /// Defines a value that will linearly move between ``a`` and ``b`` over its configured lifetime.
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect, FromReflect))]
 pub struct Lerp {
     /// The starting value, returned when ``pct`` is `0.0`.
     pub a: f32,
@@ -414,6 +423,7 @@ impl Default for Lerp {
 
 /// Defines a value that will move in a sinusoidal wave pattern over it's configured lifetime.
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect, FromReflect))]
 pub struct SinWave {
     /// The amplitude of the wave as time progresses.
     ///


### PR DESCRIPTION
This makes it possible for tools like bevy-inspector-egui to show an editor for `ParticleSystem`s.

~~Added it as a default feature so it can be disabled if not needed.~~

![image](https://user-images.githubusercontent.com/2620557/202131213-0b3d2584-b799-415e-9db8-4cfd4032e77e.png)
