### PR TITLE
Add texture atlas sprites

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -6,9 +6,10 @@ use bevy::{
 };
 use bevy_app::PluginGroup;
 use bevy_asset::AssetServer;
+
 use bevy_particle_systems::{
     ColorOverTime, ColorPoint, Gradient, JitteredValue, ParticleBurst, ParticleSystem,
-    ParticleSystemBundle, ParticleSystemPlugin, Playing, SinWave, ValueOverTime,
+    ParticleSystemBundle, ParticleSystemPlugin, ParticleTexture, Playing, SinWave, ValueOverTime,
 };
 
 fn main() {
@@ -36,7 +37,7 @@ fn startup_system(mut commands: Commands, asset_server: Res<AssetServer>) {
         .spawn(ParticleSystemBundle {
             particle_system: ParticleSystem {
                 max_particles: 50_000,
-                default_sprite: asset_server.load("px.png"),
+                texture: ParticleTexture::Sprite(asset_server.load("px.png")),
                 spawn_rate_per_second: 1000.0.into(),
                 initial_speed: JitteredValue::jittered(3.0, -1.0..1.0),
                 acceleration: ValueOverTime::Sin(SinWave {

--- a/examples/local_space.rs
+++ b/examples/local_space.rs
@@ -9,11 +9,12 @@ use bevy::{
 };
 use bevy_asset::AssetServer;
 use bevy_math::Quat;
+use bevy_time::Time;
+
 use bevy_particle_systems::{
     ColorOverTime, ColorPoint, Gradient, JitteredValue, ParticleSpace, ParticleSystem,
-    ParticleSystemBundle, ParticleSystemPlugin, Playing,
+    ParticleSystemBundle, ParticleSystemPlugin, ParticleTexture, Playing,
 };
-use bevy_time::Time;
 
 #[derive(Debug, Component)]
 pub struct Targets {
@@ -40,7 +41,7 @@ fn startup_system(mut commands: Commands, asset_server: Res<AssetServer>) {
                 max_particles: 500,
                 emitter_shape: std::f32::consts::PI * 0.25,
                 emitter_angle: 0.0,
-                default_sprite: asset_server.load("px.png"),
+                texture: ParticleTexture::Sprite(asset_server.load("px.png")),
                 spawn_rate_per_second: 35.0.into(),
                 initial_speed: JitteredValue::jittered(25.0, 0.0..5.0),
                 acceleration: 0.0.into(),
@@ -67,7 +68,7 @@ fn startup_system(mut commands: Commands, asset_server: Res<AssetServer>) {
                 max_particles: 500,
                 emitter_shape: std::f32::consts::PI * 0.25,
                 emitter_angle: std::f32::consts::PI,
-                default_sprite: asset_server.load("px.png"),
+                texture: ParticleTexture::Sprite(asset_server.load("px.png")),
                 spawn_rate_per_second: 35.0.into(),
                 initial_speed: JitteredValue::jittered(25.0, 0.0..5.0),
                 acceleration: 0.0.into(),

--- a/examples/time_scaling.rs
+++ b/examples/time_scaling.rs
@@ -11,7 +11,7 @@ use bevy::{
 use bevy_asset::AssetServer;
 use bevy_particle_systems::{
     ColorOverTime, ColorPoint, Gradient, JitteredValue, ParticleSpace, ParticleSystem,
-    ParticleSystemBundle, ParticleSystemPlugin, Playing,
+    ParticleSystemBundle, ParticleSystemPlugin, ParticleTexture, Playing,
 };
 use bevy_time::Time;
 fn main() {
@@ -32,7 +32,7 @@ fn startup_system(mut commands: Commands, asset_server: Res<AssetServer>) {
                 max_particles: 500,
                 emitter_shape: std::f32::consts::PI * 0.25,
                 emitter_angle: 0.0,
-                default_sprite: asset_server.load("px.png"),
+                texture: ParticleTexture::Sprite(asset_server.load("px.png")),
                 spawn_rate_per_second: 35.0.into(),
                 initial_speed: JitteredValue::jittered(25.0, 0.0..5.0),
                 acceleration: 0.0.into(),
@@ -59,7 +59,7 @@ fn startup_system(mut commands: Commands, asset_server: Res<AssetServer>) {
                 max_particles: 500,
                 emitter_shape: std::f32::consts::PI * 0.25,
                 emitter_angle: std::f32::consts::PI,
-                default_sprite: asset_server.load("px.png"),
+                texture: ParticleTexture::Sprite(asset_server.load("px.png")),
                 spawn_rate_per_second: 35.0.into(),
                 initial_speed: JitteredValue::jittered(25.0, 0.0..5.0),
                 acceleration: 0.0.into(),

--- a/src/components.rs
+++ b/src/components.rs
@@ -5,6 +5,7 @@ use bevy_ecs::prelude::{Bundle, Component, Entity, ReflectComponent};
 use bevy_math::Vec3;
 use bevy_reflect::prelude::*;
 use bevy_render::prelude::{Image, VisibilityBundle};
+use bevy_sprite::TextureAtlas;
 use bevy_transform::prelude::{GlobalTransform, Transform};
 
 use crate::values::{ColorOverTime, JitteredValue, ValueOverTime};
@@ -58,7 +59,18 @@ pub struct ParticleSystem {
     pub max_particles: usize,
 
     /// The sprite used for each particle.
-    pub default_sprite: Handle<Image>,
+    ///
+    /// Cannot be used at the same time as `texture_atlas`
+    pub default_sprite: Option<Handle<Image>>,
+
+    /// The texture atlas to be used for particle sprites
+    ///
+    /// Cannot be used at the same time as `default_sprite`
+    pub texture_atlas: Option<Handle<TextureAtlas>>,
+
+    // TODO: enable choosing the index with jitter or over time?
+    /// The index of the sprite in the texture atlas
+    pub texture_atlas_index: Option<usize>,
 
     /// The number of particles to spawn per second.
     ///

--- a/src/components.rs
+++ b/src/components.rs
@@ -161,7 +161,9 @@ impl Default for ParticleSystem {
     fn default() -> Self {
         Self {
             max_particles: 100,
-            default_sprite: Handle::default(),
+            default_sprite: Some(Handle::default()),
+            texture_atlas: None,
+            texture_atlas_index: None,
             spawn_rate_per_second: 5.0.into(),
             spawn_radius: 0.0.into(),
             emitter_shape: std::f32::consts::TAU,

--- a/src/components.rs
+++ b/src/components.rs
@@ -45,7 +45,7 @@ pub enum ParticleSpace {
 }
 
 /// Defines what texture to use for a particle
-#[derive(Debug, Clone, Copy, Reflect, FromReflect)]
+#[derive(Debug, Clone, Reflect, FromReflect)]
 pub enum ParticleTexture {
     /// Indicates particles should use a given image texture
     Sprite(Handle<Image>),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@
 //!     .spawn_bundle(ParticleSystemBundle {
 //!         particle_system: ParticleSystem {
 //!             max_particles: 10_000,
-//!             default_sprite: asset_server.load("my_particle.png"),
+//!             texture: ParticleTexture::Sprite(asset_server.load("px.png")),
 //!             spawn_rate_per_second: 25.0.into(),
 //!             initial_speed: JitteredValue::jittered(3.0, -1.0..1.0),
 //!             lifetime: JitteredValue::jittered(8.0, -2.0..2.0),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@ pub mod values;
 use bevy_app::prelude::{App, Plugin};
 pub use components::*;
 use systems::{
-    partcle_spawner, particle_cleanup, particle_color, particle_lifetime, particle_transform,
+    particle_spawner, particle_cleanup, particle_color, particle_lifetime, particle_transform,
 };
 pub use values::*;
 
@@ -91,7 +91,7 @@ pub struct ParticleSystemPlugin;
 
 impl Plugin for ParticleSystemPlugin {
     fn build(&self, app: &mut App) {
-        app.add_system(partcle_spawner)
+        app.add_system(particle_spawner)
             .add_system(particle_lifetime)
             .add_system(particle_color)
             .add_system(particle_transform)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@ pub mod values;
 use bevy_app::prelude::{App, Plugin};
 pub use components::*;
 use systems::{
-    particle_spawner, particle_cleanup, particle_color, particle_lifetime, particle_transform,
+    particle_cleanup, particle_color, particle_lifetime, particle_spawner, particle_transform,
 };
 pub use values::*;
 

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -1,7 +1,10 @@
+use bevy_asset::Handle;
 use bevy_ecs::prelude::{Commands, Entity, Query, Res, With};
 use bevy_hierarchy::BuildChildren;
 use bevy_math::Vec3;
+use bevy_render::prelude::Image;
 use bevy_sprite::prelude::{Sprite, SpriteBundle};
+use bevy_sprite::{SpriteSheetBundle, TextureAtlasSprite};
 use bevy_time::Time;
 use bevy_transform::prelude::{GlobalTransform, Transform};
 use rand::prelude::*;
@@ -22,7 +25,7 @@ use crate::{
     clippy::type_complexity,
     clippy::too_many_lines
 )]
-pub fn partcle_spawner(
+pub fn particle_spawner(
     mut particle_systems: Query<
         (
             Entity,
@@ -130,7 +133,7 @@ pub fn partcle_spawner(
 
             match particle_system.space {
                 ParticleSpace::World => {
-                    commands
+                    let mut entity_commands = commands
                         .spawn(ParticleBundle {
                             particle: Particle {
                                 parent_system: entity,
@@ -148,20 +151,41 @@ pub fn partcle_spawner(
                                 particle_system.z_value_override.is_some(),
                             ),
                             ..ParticleBundle::default()
-                        })
-                        .insert(SpriteBundle {
-                            sprite: Sprite {
-                                color: particle_system.color.at_lifetime_pct(0.0),
-                                ..Sprite::default()
-                            },
-                            transform: spawn_point,
-                            texture: particle_system.default_sprite.clone(),
-                            ..SpriteBundle::default()
                         });
+
+                    if Some(image_handle) = particle_system.default_sprite.as_ref() {
+                        entity_commands.insert(
+                            SpriteBundle {
+                                sprite: Sprite {
+                                    color: particle_system.color.at_lifetime_pct(0.0),
+                                    ..Sprite::default()
+                                },
+                                transform: spawn_point,
+                                texture: image_handle.clone(),
+                                ..SpriteBundle::default()
+                            }
+                        );
+                    }
+                    if Some(atlas_handle) = particle_system.texture_atlas.as_ref() {
+                        if Some(atlas_index) = particle_system.texture_atlas_index {
+                            entity_commands.insert(
+                                SpriteSheetBundle {
+                                    sprite: TextureAtlasSprite {
+                                        color: particle_system.color.at_lifetime_pct(0.0),
+                                        index: atlas_index,
+                                        ..TextureAtlasSprite::default()
+                                    },
+                                    transform: spawn_point,
+                                    texture_atlas: atlas_handle.clone(),
+                                    ..SpriteSheetBundle::default()
+                                }
+                            );
+                        }
+                    }
                 }
                 ParticleSpace::Local => {
                     commands.entity(entity).with_children(|parent| {
-                        parent
+                        let mut entity_commands = parent
                             .spawn(ParticleBundle {
                                 particle: Particle {
                                     parent_system: entity,
@@ -180,16 +204,37 @@ pub fn partcle_spawner(
                                     particle_system.z_value_override.is_some(),
                                 ),
                                 ..ParticleBundle::default()
-                            })
-                            .insert(SpriteBundle {
-                                sprite: Sprite {
-                                    color: particle_system.color.at_lifetime_pct(0.0),
-                                    ..Sprite::default()
-                                },
-                                transform: spawn_point,
-                                texture: particle_system.default_sprite.clone(),
-                                ..SpriteBundle::default()
                             });
+
+                        if Some(image_handle) = particle_system.default_sprite.as_ref() {
+                            entity_commands.insert(
+                                SpriteBundle {
+                                    sprite: Sprite {
+                                        color: particle_system.color.at_lifetime_pct(0.0),
+                                        ..Sprite::default()
+                                    },
+                                    transform: spawn_point,
+                                    texture: image_handle.clone(),
+                                    ..SpriteBundle::default()
+                                }
+                            );
+                        }
+                        if Some(atlas_handle) = particle_system.texture_atlas.as_ref() {
+                            if Some(atlas_index) = particle_system.texture_atlas_index {
+                                entity_commands.insert(
+                                    SpriteSheetBundle {
+                                        sprite: TextureAtlasSprite {
+                                            color: particle_system.color.at_lifetime_pct(0.0),
+                                            index: atlas_index,
+                                            ..TextureAtlasSprite::default()
+                                        },
+                                        transform: spawn_point,
+                                        texture_atlas: atlas_handle.clone(),
+                                        ..SpriteSheetBundle::default()
+                                    }
+                                );
+                            }
+                        }
                     });
                 }
             }

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -152,7 +152,7 @@ pub fn particle_spawner(
                         ..ParticleBundle::default()
                     });
 
-                    match particle_system.texture.as_ref() {
+                    match &particle_system.texture {
                         &ParticleTexture::Sprite(image_handle) => {
                             entity_commands.insert(SpriteBundle {
                                 sprite: Sprite {
@@ -202,7 +202,7 @@ pub fn particle_spawner(
                             ..ParticleBundle::default()
                         });
 
-                        match particle_system.texture.as_ref() {
+                        match &particle_system.texture {
                             &ParticleTexture::Sprite(image_handle) => {
                                 entity_commands.insert(SpriteBundle {
                                     sprite: Sprite {

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -153,7 +153,7 @@ pub fn particle_spawner(
                             ..ParticleBundle::default()
                         });
 
-                    if Some(image_handle) = particle_system.default_sprite.as_ref() {
+                    if let Some(image_handle) = particle_system.default_sprite.as_ref() {
                         entity_commands.insert(
                             SpriteBundle {
                                 sprite: Sprite {
@@ -166,8 +166,8 @@ pub fn particle_spawner(
                             }
                         );
                     }
-                    if Some(atlas_handle) = particle_system.texture_atlas.as_ref() {
-                        if Some(atlas_index) = particle_system.texture_atlas_index {
+                    if let Some(atlas_handle) = particle_system.texture_atlas.as_ref() {
+                        if let Some(atlas_index) = particle_system.texture_atlas_index {
                             entity_commands.insert(
                                 SpriteSheetBundle {
                                     sprite: TextureAtlasSprite {
@@ -206,7 +206,7 @@ pub fn particle_spawner(
                                 ..ParticleBundle::default()
                             });
 
-                        if Some(image_handle) = particle_system.default_sprite.as_ref() {
+                        if let Some(image_handle) = particle_system.default_sprite.as_ref() {
                             entity_commands.insert(
                                 SpriteBundle {
                                     sprite: Sprite {
@@ -219,8 +219,8 @@ pub fn particle_spawner(
                                 }
                             );
                         }
-                        if Some(atlas_handle) = particle_system.texture_atlas.as_ref() {
-                            if Some(atlas_index) = particle_system.texture_atlas_index {
+                        if let Some(atlas_handle) = particle_system.texture_atlas.as_ref() {
+                            if let Some(atlas_index) = particle_system.texture_atlas_index {
                                 entity_commands.insert(
                                     SpriteSheetBundle {
                                         sprite: TextureAtlasSprite {

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -1,8 +1,6 @@
-use bevy_asset::Handle;
 use bevy_ecs::prelude::{Commands, Entity, Query, Res, With};
 use bevy_hierarchy::BuildChildren;
 use bevy_math::Vec3;
-use bevy_render::prelude::Image;
 use bevy_sprite::prelude::{Sprite, SpriteBundle};
 use bevy_sprite::{SpriteSheetBundle, TextureAtlasSprite};
 use bevy_time::Time;
@@ -153,7 +151,7 @@ pub fn particle_spawner(
                     });
 
                     match &particle_system.texture {
-                        &ParticleTexture::Sprite(image_handle) => {
+                        ParticleTexture::Sprite(image_handle) => {
                             entity_commands.insert(SpriteBundle {
                                 sprite: Sprite {
                                     color: particle_system.color.at_lifetime_pct(0.0),
@@ -164,9 +162,9 @@ pub fn particle_spawner(
                                 ..SpriteBundle::default()
                             });
                         }
-                        &ParticleTexture::TextureAtlas {
+                        ParticleTexture::TextureAtlas {
                             atlas: atlas_handle,
-                            index: index,
+                            index,
                         } => {
                             entity_commands.insert(SpriteSheetBundle {
                                 sprite: TextureAtlasSprite {
@@ -203,7 +201,7 @@ pub fn particle_spawner(
                         });
 
                         match &particle_system.texture {
-                            &ParticleTexture::Sprite(image_handle) => {
+                            ParticleTexture::Sprite(image_handle) => {
                                 entity_commands.insert(SpriteBundle {
                                     sprite: Sprite {
                                         color: particle_system.color.at_lifetime_pct(0.0),
@@ -214,9 +212,9 @@ pub fn particle_spawner(
                                     ..SpriteBundle::default()
                                 });
                             }
-                            &ParticleTexture::TextureAtlas {
+                            ParticleTexture::TextureAtlas {
                                 atlas: atlas_handle,
-                                index: index,
+                                index,
                             } => {
                                 entity_commands.insert(SpriteSheetBundle {
                                     sprite: TextureAtlasSprite {

--- a/src/values.rs
+++ b/src/values.rs
@@ -46,7 +46,9 @@ impl<T: Reflect + Clone + FromReflect> From<T> for RandomValue<T> {
 }
 
 impl<T: Reflect + Clone + FromReflect> From<Range<T>> for RandomValue<T>
-where Range<T>: Iterator<Item = T> {
+where
+    Range<T>: Iterator<Item = T>,
+{
     fn from(r: Range<T>) -> Self {
         RandomValue::RandomChoice(r.collect())
     }
@@ -68,9 +70,12 @@ impl<T: Reflect + Clone + FromReflect> RandomValue<T> {
         match self {
             Self::Constant(t) => t.clone(),
             Self::RandomChoice(v) => {
-                assert!(!v.is_empty(), "RandomValue::RandomChoice has no values to choose from!");
+                assert!(
+                    !v.is_empty(),
+                    "RandomValue::RandomChoice has no values to choose from!"
+                );
                 v.choose(rng).unwrap().clone()
-            },
+            }
         }
     }
 }

--- a/src/values.rs
+++ b/src/values.rs
@@ -32,7 +32,7 @@ use rand::{prelude::ThreadRng, Rng};
 /// ```
 
 #[derive(Debug, Clone, Reflect, FromReflect)]
-pub enum RandomValue<T: Reflect> {
+pub enum RandomValue<T: Reflect + Clone + FromReflect> {
     /// A constant value
     Constant(T),
 
@@ -44,25 +44,25 @@ pub enum RandomValue<T: Reflect> {
     RandomChoice(Vec<T>),
 }
 
-impl<T: Reflect> From<T> for RandomValue<T> {
+impl<T: Reflect + Clone + FromReflect> From<T> for RandomValue<T> {
     fn from(t: T) -> Self {
         RandomValue::Constant(t)
     }
 }
 
-impl<T: Reflect> From<Range<T>> for RandomValue<T> {
+impl<T: Reflect + Clone + FromReflect> From<Range<T>> for RandomValue<T> {
     fn from(r: Range<T>) -> Self {
         RandomValue::RandomRange(r)
     }
 }
 
-impl<T: Reflect> From<Vec<T>> for RandomValue<T> {
+impl<T: Reflect + Clone + FromReflect> From<Vec<T>> for RandomValue<T> {
     fn from(v: Vec<T>) -> Self {
         RandomValue::RandomChoice(v)
     }
 }
 
-impl<T: Reflect> RandomValue<T> {
+impl<T: Reflect + Clone + FromReflect> RandomValue<T> {
     /// Get a value from the set of possible values
     pub fn get_value(&self, rng: &mut ThreadRng) -> T {
         match self {

--- a/src/values.rs
+++ b/src/values.rs
@@ -31,13 +31,14 @@ use rand::{prelude::ThreadRng, Rng};
 /// let v: RandomValue<usize> = vec![0, 2, 4, 8].into();
 /// ```
 
-#[derive(Debug, Clone, Reflect, FromReflect)]
-pub enum RandomValue<T: Reflect> {
+// TODO: derive Reflect/FromReflect if only if T derives Reflect.
+#[derive(Debug, Clone)]
+pub enum RandomValue<T> {
     /// A constant value
     Constant(T),
 
     /// A [`Range`] of possible values to choose from randomly
-    /// TODO: must T derive PartialOrd?
+    // TODO: must T derive PartialOrd?
     RandomRange(Range<T>),
 
     /// A set of possible values to choose from randomly

--- a/src/values.rs
+++ b/src/values.rs
@@ -45,7 +45,8 @@ impl<T: Reflect + Clone + FromReflect> From<T> for RandomValue<T> {
     }
 }
 
-impl<T: Reflect + Clone + FromReflect> From<Range<T>> for RandomValue<T> {
+impl<T: Reflect + Clone + FromReflect> From<Range<T>> for RandomValue<T>
+where Range<T>: Iterator<Item = T> {
     fn from(r: Range<T>) -> Self {
         RandomValue::RandomChoice(r.collect())
     }

--- a/src/values.rs
+++ b/src/values.rs
@@ -60,11 +60,15 @@ impl<T: Reflect + Clone + FromReflect> From<Vec<T>> for RandomValue<T> {
 
 impl<T: Reflect + Clone + FromReflect> RandomValue<T> {
     /// Get a value from the set of possible values
+    ///
+    /// # Panics
+    ///
+    /// Will panic if there are no values to choose from
     pub fn get_value(&self, rng: &mut ThreadRng) -> T {
         match self {
             Self::Constant(t) => t.clone(),
             Self::RandomChoice(v) => {
-                assert!(!v.is_empty(), "cannot choose RandomValue::RandomChoice from empty vec !");
+                assert!(!v.is_empty(), "RandomValue::RandomChoice has no values to choose from!");
                 v.choose(rng).unwrap().clone()
             },
         }

--- a/src/values.rs
+++ b/src/values.rs
@@ -50,7 +50,7 @@ impl<T: Reflect + Clone + FromReflect> From<T> for RandomValue<T> {
     }
 }
 
-impl<T: Reflect + Clone + FromReflect> From<Range<T>> for RandomValue<T> {
+impl<T: Reflect + Clone + FromReflect + PartialOrd> From<Range<T>> for RandomValue<T> {
     fn from(r: Range<T>) -> Self {
         RandomValue::RandomRange(r)
     }

--- a/src/values.rs
+++ b/src/values.rs
@@ -11,8 +11,7 @@ use rand::{prelude::ThreadRng, Rng};
 /// ## Examples
 ///
 /// ``T`` values can be converted into ``Constant``
-/// [`Range<T>`]s can be converted into ``RandomRange``
-/// [`Vec<T>`]s can be converted in ``RandomChoice``
+/// [`Range<T>`]s or [`Vec<T>`]s can be converted into ``RandomChoice``
 ///
 /// ## Examples
 /// ```
@@ -36,10 +35,6 @@ pub enum RandomValue<T: Reflect + Clone + FromReflect> {
     /// A constant value
     Constant(T),
 
-    /// A [`Range`] of possible values to choose from randomly
-    // TODO: must T derive PartialOrd?
-    RandomRange(Range<T>),
-
     /// A set of possible values to choose from randomly
     RandomChoice(Vec<T>),
 }
@@ -50,9 +45,9 @@ impl<T: Reflect + Clone + FromReflect> From<T> for RandomValue<T> {
     }
 }
 
-impl<T: Reflect + Clone + FromReflect + PartialOrd> From<Range<T>> for RandomValue<T> {
+impl<T: Reflect + Clone + FromReflect> From<Range<T>> for RandomValue<T> {
     fn from(r: Range<T>) -> Self {
-        RandomValue::RandomRange(r)
+        RandomValue::RandomChoice(r.collect())
     }
 }
 
@@ -67,7 +62,6 @@ impl<T: Reflect + Clone + FromReflect> RandomValue<T> {
     pub fn get_value(&self, rng: &mut ThreadRng) -> T {
         match self {
             Self::Constant(t) => t.clone(),
-            Self::RandomRange(r) => rng.gen_range(r.clone()),
             Self::RandomChoice(v) => {
                 assert!(!v.is_empty(), "cannot choose RandomValue::RandomChoice from empty vec !");
                 v.choose(rng).unwrap().clone()

--- a/src/values.rs
+++ b/src/values.rs
@@ -32,7 +32,7 @@ use rand::{prelude::ThreadRng, Rng};
 /// ```
 
 #[derive(Debug, Clone, Reflect, FromReflect)]
-pub enum RandomValue<T> {
+pub enum RandomValue<T: Reflect> {
     /// A constant value
     Constant(T),
 

--- a/src/values.rs
+++ b/src/values.rs
@@ -3,7 +3,75 @@ use std::ops::Range;
 
 use bevy_reflect::{FromReflect, Reflect};
 use bevy_render::prelude::Color;
+use rand::seq::SliceRandom;
 use rand::{prelude::ThreadRng, Rng};
+
+/// A value that will be chosen from a set of possible values when read.
+///
+/// ## Examples
+///
+/// ``T`` values can be converted into ``Constant``
+/// [`Range<T>`]s can be converted into ``RandomRange``
+/// [`Vec<T>`]s can be converted in ``RandomChoice``
+///
+/// ## Examples
+/// ```
+/// # use bevy_particle_systems::values::{RandomValue};
+/// # use rand;
+///
+/// let mut rng = rand::thread_rng();
+///
+/// // Results in a constant value
+/// let c: RandomValue<usize> = (2).into();
+///
+/// // Results are picked randomly from a range
+/// let r: RandomValue<usize> = (1..3).into();
+///
+/// // Results are picked randomly from a set of values
+/// let v: RandomValue<usize> = vec![0, 2, 4, 8].into();
+/// ```
+
+#[derive(Debug, Clone, Reflect, FromReflect)]
+pub enum RandomValue<T> {
+    /// A constant value
+    Constant(T),
+
+    /// A [`Range`] of possible values to choose from randomly
+    /// TODO: must T derive PartialOrd?
+    RandomRange(Range<T>),
+
+    /// A set of possible values to choose from randomly
+    RandomChoice(Vec<T>),
+}
+
+impl<T> From<T> for RandomValue<T> {
+    fn from(t: T) -> Self {
+        RandomValue::Constant(t)
+    }
+}
+
+impl<T> From<Range<T>> for RandomValue<T> {
+    fn from(r: Range<T>) -> Self {
+        RandomValue::RandomRange(r)
+    }
+}
+
+impl<T> From<Vec<T>> for RandomValue<T> {
+    fn from(v: Vec<T>) -> Self {
+        RandomValue::RandomChoice(v)
+    }
+}
+
+impl<T> RandomValue<T> {
+    /// Get a value from the set of possible values
+    pub fn get_value<T>(&self, rng: &mut ThreadRng) -> T {
+        match self {
+            Self::Constant(t) => t,
+            Self::RandomRange(r) => rng.gen_range(r),
+            Self::RandomChoice(v) => v.choose(rng),
+        }
+    }
+}
 
 /// A value that has random jitter within a configured range added to it when read.
 ///

--- a/src/values.rs
+++ b/src/values.rs
@@ -64,7 +64,7 @@ impl<T> From<Vec<T>> for RandomValue<T> {
 
 impl<T> RandomValue<T> {
     /// Get a value from the set of possible values
-    pub fn get_value<T>(&self, rng: &mut ThreadRng) -> T {
+    pub fn get_value(&self, rng: &mut ThreadRng) -> T {
         match self {
             Self::Constant(t) => t,
             Self::RandomRange(r) => rng.gen_range(r),


### PR DESCRIPTION
PR to be able to handle sprites that come from texture atlas.

My use-case is that all my image assets are stored in a texture atlas, so I need this change to be able to use the library.
I think that it would be interesting to let users have a particle sprite-sheet and the particles randomly use a sprite from the sprite sheet.

This PR is unpolished, I just opened it to see if it's a good idea for you.
If so, I would probably add an SpriteEnum to have 2 mutually exclusive options (Sprite or TextureAtlasSprite)