### PR TITLE
Add system labels

### DIFF
--- a/src/components.rs
+++ b/src/components.rs
@@ -278,9 +278,6 @@ impl Direction {
     }
 }
 
-/// Marker component indicating that the [`ParticleSystem`] on the same entity is currently Playing.
-#[derive(Debug, Component)]
-pub struct Playing;
 
 /// Tracks running state of the [`ParticleSystem`] on the same entity.
 #[derive(Debug, Component, Default, Reflect)]
@@ -288,7 +285,7 @@ pub struct Playing;
 pub struct RunningState {
     /// Tracks the current amount of time since the start of the system.
     ///
-    /// This is reset when the running time surpases the ``system_duration_seconds``.
+    /// This is reset when the running time surpasses the ``system_duration_seconds``.
     pub running_time: f32,
 
     /// The truncated current second.

--- a/src/components.rs
+++ b/src/components.rs
@@ -278,6 +278,9 @@ impl Direction {
     }
 }
 
+/// Marker component indicating that the [`ParticleSystem`] on the same entity is currently Playing.
+#[derive(Debug, Component)]
+pub struct Playing;
 
 /// Tracks running state of the [`ParticleSystem`] on the same entity.
 #[derive(Debug, Component, Default, Reflect)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,7 @@ impl Plugin for ParticleSystemPlugin {
                 .after(ParticleSystemLabel::ParticleSpawn)
                 .with_system(particle_lifetime)
                 .with_system(particle_color)
-                .with_system(particle_transform)
+                .with_system(particle_transform),
         );
         app.add_system(particle_cleanup.label(ParticleSystemLabel::ParticleCleanup));
         app.register_type::<ParticleSystem>()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,11 +63,13 @@ mod systems;
 pub mod values;
 
 use bevy_app::prelude::{App, Plugin};
+use bevy_ecs::prelude::{IntoSystemDescriptor, SystemSet};
 pub use components::*;
 use systems::{
     particle_cleanup, particle_color, particle_lifetime, particle_spawner, particle_transform,
 };
 pub use values::*;
+use crate::systems::ParticleSystemLabel;
 
 /// The plugin component to be added to allow particle systems to run.
 ///
@@ -91,12 +93,17 @@ pub struct ParticleSystemPlugin;
 
 impl Plugin for ParticleSystemPlugin {
     fn build(&self, app: &mut App) {
-        app.add_system(particle_spawner)
-            .add_system(particle_lifetime)
-            .add_system(particle_color)
-            .add_system(particle_transform)
-            .add_system(particle_cleanup)
-            .register_type::<ParticleSystem>()
+        app.add_system(particle_spawner.label(ParticleSystemLabel::ParticleSpawn));
+        app.add_system_set(
+            SystemSet::new()
+                .label(ParticleSystemLabel::ParticleUpdate)
+                .after(ParticleSystemLabel::ParticleSpawn)
+                .with_system(particle_lifetime)
+                .with_system(particle_color)
+                .with_system(particle_transform)
+        );
+        app.add_system(particle_cleanup.label(ParticleSystemLabel::ParticleCleanup));
+        app.register_type::<ParticleSystem>()
             .register_type::<ParticleCount>()
             .register_type::<RunningState>()
             .register_type::<BurstIndex>();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,11 +65,11 @@ pub mod values;
 use bevy_app::prelude::{App, Plugin};
 use bevy_ecs::prelude::{IntoSystemDescriptor, SystemSet};
 pub use components::*;
+pub use systems::ParticleSystemLabel;
 use systems::{
     particle_cleanup, particle_color, particle_lifetime, particle_spawner, particle_transform,
 };
 pub use values::*;
-use crate::systems::ParticleSystemLabel;
 
 /// The plugin component to be added to allow particle systems to run.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@ mod systems;
 pub mod values;
 
 use bevy_app::prelude::{App, Plugin};
-use bevy_ecs::prelude::{IntoSystemDescriptor, SystemSet};
+use bevy_ecs::prelude::SystemSet;
 pub use components::*;
 pub use systems::ParticleSystemLabel;
 use systems::{
@@ -93,16 +93,15 @@ pub struct ParticleSystemPlugin;
 
 impl Plugin for ParticleSystemPlugin {
     fn build(&self, app: &mut App) {
-        app.add_system(particle_spawner.label(ParticleSystemLabel::ParticleSpawn));
         app.add_system_set(
             SystemSet::new()
-                .label(ParticleSystemLabel::ParticleUpdate)
-                .after(ParticleSystemLabel::ParticleSpawn)
+                .label(ParticleSystemLabel::ParticleSystem)
+                .with_system(particle_spawner)
                 .with_system(particle_lifetime)
                 .with_system(particle_color)
-                .with_system(particle_transform),
+                .with_system(particle_transform)
+                .with_system(particle_cleanup),
         );
-        app.add_system(particle_cleanup.label(ParticleSystemLabel::ParticleCleanup));
         app.register_type::<ParticleSystem>()
             .register_type::<ParticleCount>()
             .register_type::<RunningState>()

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -1,5 +1,5 @@
 use bevy_ecs::prelude::{Commands, Entity, Query, Res, With};
-use bevy_ecs::schedule::{SystemLabel, SystemSet};
+use bevy_ecs::schedule::{SystemLabel};
 use bevy_hierarchy::BuildChildren;
 use bevy_math::Vec3;
 use bevy_sprite::prelude::{Sprite, SpriteBundle};
@@ -17,7 +17,7 @@ use crate::{
     DistanceTraveled, ParticleTexture,
 };
 
-/// System label attached to the [`SystemSet`] provided in this plugin
+/// System label attached to the `SystemSet` provided in this plugin
 ///
 /// This is provided so that users can order their systems to run before/after this plugin.
 #[derive(Debug, SystemLabel)]

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -1,4 +1,5 @@
 use bevy_ecs::prelude::{Commands, Entity, Query, Res, With};
+use bevy_ecs::schedule::SystemLabel;
 use bevy_hierarchy::BuildChildren;
 use bevy_math::Vec3;
 use bevy_sprite::prelude::{Sprite, SpriteBundle};

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -17,15 +17,13 @@ use crate::{
     DistanceTraveled, ParticleTexture,
 };
 
-/// Label enum for the systems relating to transform propagation
-#[derive(Debug, Hash, PartialEq, Eq, Clone, SystemLabel)]
+/// System label attached to the SystemSet provided in this plugin
+///
+/// This is provided so that users can order their systems to run before/after this plugin.
+#[derive(Debug, SystemLabel)]
 pub enum ParticleSystemLabel {
-    /// Spawn particles
-    ParticleSpawn,
-    /// Update particles
-    ParticleUpdate,
-    /// Cleanup particles
-    ParticleCleanup,
+    /// Label for the main systems
+    ParticleSystem,
 }
 
 #[allow(

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -1,5 +1,5 @@
 use bevy_ecs::prelude::{Commands, Entity, Query, Res, With};
-use bevy_ecs::schedule::SystemLabel;
+use bevy_ecs::schedule::{SystemLabel, SystemSet};
 use bevy_hierarchy::BuildChildren;
 use bevy_math::Vec3;
 use bevy_sprite::prelude::{Sprite, SpriteBundle};
@@ -17,7 +17,7 @@ use crate::{
     DistanceTraveled, ParticleTexture,
 };
 
-/// System label attached to the SystemSet provided in this plugin
+/// System label attached to the [`SystemSet`] provided in this plugin
 ///
 /// This is provided so that users can order their systems to run before/after this plugin.
 #[derive(Debug, SystemLabel)]

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -1,5 +1,5 @@
 use bevy_ecs::prelude::{Commands, Entity, Query, Res, With};
-use bevy_ecs::schedule::{SystemLabel};
+use bevy_ecs::schedule::SystemLabel;
 use bevy_hierarchy::BuildChildren;
 use bevy_math::Vec3;
 use bevy_sprite::prelude::{Sprite, SpriteBundle};

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -17,7 +17,6 @@ use crate::{
     DistanceTraveled, ParticleTexture,
 };
 
-
 /// Label enum for the systems relating to transform propagation
 #[derive(Debug, Hash, PartialEq, Eq, Clone, SystemLabel)]
 pub enum ParticleSystemLabel {

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -16,6 +16,18 @@ use crate::{
     DistanceTraveled, ParticleTexture,
 };
 
+
+/// Label enum for the systems relating to transform propagation
+#[derive(Debug, Hash, PartialEq, Eq, Clone, SystemLabel)]
+pub enum ParticleSystemLabel {
+    /// Spawn particles
+    ParticleSpawn,
+    /// Update particles
+    ParticleUpdate,
+    /// Cleanup particles
+    ParticleCleanup,
+}
+
 #[allow(
     clippy::cast_sign_loss,
     clippy::cast_precision_loss,


### PR DESCRIPTION
I wanted to create some systems in my game that manually overrode the particle `Transform` component.

For that I need to be able to order my systems to run after the `particle_transform` update; I added some SystemLabels to that effect.