### PR TITLE
Add option to rescale sprites

### DIFF
--- a/src/components.rs
+++ b/src/components.rs
@@ -2,7 +2,7 @@
 
 use bevy_asset::Handle;
 use bevy_ecs::prelude::{Bundle, Component, Entity, ReflectComponent};
-use bevy_math::Vec3;
+use bevy_math::{Vec2, Vec3};
 use bevy_reflect::prelude::*;
 use bevy_render::prelude::{Image, VisibilityBundle};
 use bevy_sprite::TextureAtlas;
@@ -74,6 +74,11 @@ pub struct ParticleSystem {
 
     /// The texture used for each particle.
     pub texture: ParticleTexture,
+
+    /// If provided, re-scale the texture size
+    ///
+    /// Note that this the inherent Sprite size, which can still be scaled up with `Transform`
+    pub rescale_texture: Option<Vec2>,
 
     /// The number of particles to spawn per second.
     ///
@@ -165,6 +170,7 @@ impl Default for ParticleSystem {
         Self {
             max_particles: 100,
             texture: ParticleTexture::Sprite(Handle::default()),
+            rescale_texture: None,
             spawn_rate_per_second: 5.0.into(),
             spawn_radius: 0.0.into(),
             emitter_shape: std::f32::consts::TAU,

--- a/src/components.rs
+++ b/src/components.rs
@@ -77,7 +77,7 @@ pub struct ParticleSystem {
 
     /// If provided, re-scale the texture size
     ///
-    /// Note that this the inherent Sprite size, which can still be scaled up with `Transform`
+    /// This is simply passed directly to [`Sprite::custom_size`] or [`TextureAtlasSprite::custom_size`]
     pub rescale_texture: Option<Vec2>,
 
     /// The number of particles to spawn per second.

--- a/src/components.rs
+++ b/src/components.rs
@@ -5,7 +5,7 @@ use bevy_ecs::prelude::{Bundle, Component, Entity, ReflectComponent};
 use bevy_math::{Vec2, Vec3};
 use bevy_reflect::prelude::*;
 use bevy_render::prelude::{Image, VisibilityBundle};
-use bevy_sprite::TextureAtlas;
+use bevy_sprite::{TextureAtlas, Sprite, TextureAtlasSprite};
 use bevy_transform::prelude::{GlobalTransform, Transform};
 
 use crate::values::{ColorOverTime, JitteredValue, RandomValue, ValueOverTime};

--- a/src/components.rs
+++ b/src/components.rs
@@ -5,7 +5,7 @@ use bevy_ecs::prelude::{Bundle, Component, Entity, ReflectComponent};
 use bevy_math::{Vec2, Vec3};
 use bevy_reflect::prelude::*;
 use bevy_render::prelude::{Image, VisibilityBundle};
-use bevy_sprite::{TextureAtlas, Sprite, TextureAtlasSprite};
+use bevy_sprite::{Sprite, TextureAtlas, TextureAtlasSprite};
 use bevy_transform::prelude::{GlobalTransform, Transform};
 
 use crate::values::{ColorOverTime, JitteredValue, RandomValue, ValueOverTime};

--- a/src/components.rs
+++ b/src/components.rs
@@ -5,7 +5,7 @@ use bevy_ecs::prelude::{Bundle, Component, Entity, ReflectComponent};
 use bevy_math::{Vec2, Vec3};
 use bevy_reflect::prelude::*;
 use bevy_render::prelude::{Image, VisibilityBundle};
-use bevy_sprite::{Sprite, TextureAtlas, TextureAtlasSprite};
+use bevy_sprite::TextureAtlas;
 use bevy_transform::prelude::{GlobalTransform, Transform};
 
 use crate::values::{ColorOverTime, JitteredValue, RandomValue, ValueOverTime};
@@ -77,7 +77,7 @@ pub struct ParticleSystem {
 
     /// If provided, re-scale the texture size
     ///
-    /// This is simply passed directly to [`Sprite::custom_size`] or [`TextureAtlasSprite::custom_size`]
+    /// This is simply passed directly to `Sprite::custom_size` or `TextureAtlasSprite::custom_size`
     pub rescale_texture: Option<Vec2>,
 
     /// The number of particles to spawn per second.

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -154,6 +154,7 @@ pub fn particle_spawner(
                         ParticleTexture::Sprite(image_handle) => {
                             entity_commands.insert(SpriteBundle {
                                 sprite: Sprite {
+                                    custom_size: particle_system.rescale_texture,
                                     color: particle_system.color.at_lifetime_pct(0.0),
                                     ..Sprite::default()
                                 },
@@ -168,6 +169,7 @@ pub fn particle_spawner(
                         } => {
                             entity_commands.insert(SpriteSheetBundle {
                                 sprite: TextureAtlasSprite {
+                                    custom_size: particle_system.rescale_texture,
                                     color: particle_system.color.at_lifetime_pct(0.0),
                                     index: index.get_value(&mut rng),
                                     ..TextureAtlasSprite::default()
@@ -204,6 +206,7 @@ pub fn particle_spawner(
                             ParticleTexture::Sprite(image_handle) => {
                                 entity_commands.insert(SpriteBundle {
                                     sprite: Sprite {
+                                        custom_size: particle_system.rescale_texture,
                                         color: particle_system.color.at_lifetime_pct(0.0),
                                         ..Sprite::default()
                                     },
@@ -218,6 +221,7 @@ pub fn particle_spawner(
                             } => {
                                 entity_commands.insert(SpriteSheetBundle {
                                     sprite: TextureAtlasSprite {
+                                        custom_size: particle_system.rescale_texture,
                                         color: particle_system.color.at_lifetime_pct(0.0),
                                         index: index.get_value(&mut rng),
                                         ..TextureAtlasSprite::default()


### PR DESCRIPTION
The sprites I use are of a given size, but in my game I like to use `transform.scale` to set the exact size of an entity, not to just scale it up or down.

Hence, I usually manually scale all sprites to `Vec2(1.0, 1.0)`, so that the `transform.scale` is the final size of my object.

I think it would be useful to let users have this option. Another way they could do it is to load the particule image directly, compute it's size, and change the `scale` themselves accordingly, but it's somewhat of a hassle compared to just setting the `custom_size` to `(1.0, 1.0)`