### PR TITLE
Fix particle color gradients when using texture atlas particles

### DIFF
--- a/assets/projectiles.png
+++ b/assets/projectiles.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5885cd4e643dee42d9c81e2146db3badec9dff7552be07589b86aa9ef4cd72cc
+size 1187

--- a/examples/local_space.rs
+++ b/examples/local_space.rs
@@ -108,7 +108,7 @@ pub fn circler(
     time: Res<Time>,
     mut particle_system_query: Query<(&Circler, &mut Transform), With<ParticleSystem>>,
 ) {
-    let rad = time.elapsed_seconds() as f32;
+    let rad = time.elapsed_seconds();
     let quat = Quat::from_rotation_z(rad).normalize();
     let dir = quat * Vec3::Y;
     for (circler, mut transform) in &mut particle_system_query {

--- a/examples/texture_atlas.rs
+++ b/examples/texture_atlas.rs
@@ -1,0 +1,57 @@
+use bevy::{
+    prelude::{Camera2dBundle, ClearColor, Color, Commands, Res, ResMut},
+    DefaultPlugins,
+};
+use bevy_app::App;
+use bevy_asset::{AssetServer, Assets};
+use bevy_math::Vec2;
+use bevy_particle_systems::{
+    ColorOverTime, ColorPoint, Gradient, JitteredValue, ParticleSystem, ParticleSystemBundle,
+    ParticleSystemPlugin, ParticleTexture, Playing,
+};
+use bevy_sprite::TextureAtlas;
+
+fn main() {
+    App::new()
+        .insert_resource(ClearColor(Color::BLACK))
+        .add_plugins(DefaultPlugins)
+        .add_plugin(ParticleSystemPlugin)
+        .add_startup_system(startup_system)
+        .run();
+}
+
+fn startup_system(
+    mut commands: Commands,
+    asset_server: Res<AssetServer>,
+    mut atlases: ResMut<Assets<TextureAtlas>>,
+) {
+    let projectiles = asset_server.load("projectiles.png");
+    let particle_atlas = atlases.add(TextureAtlas::from_grid(
+        projectiles,
+        Vec2::new(32.0, 32.0),
+        5,
+        8,
+        None,
+        None,
+    ));
+    commands.spawn(Camera2dBundle::default());
+    commands
+        .spawn(ParticleSystemBundle {
+            particle_system: ParticleSystem {
+                texture: ParticleTexture::TextureAtlas {
+                    atlas: particle_atlas,
+                    index: Vec::from([10, 11, 12, 13, 15, 16, 17, 18]).into(),
+                },
+                lifetime: 3.0.into(),
+                initial_speed: JitteredValue::jittered(150.0, -50.0..50.0),
+                scale: 1.5.into(),
+                color: ColorOverTime::Gradient(Gradient::new(vec![
+                    ColorPoint::new(Color::WHITE, 0.0),
+                    ColorPoint::new(Color::rgba(1.0, 1.0, 1.0, 0.0), 1.0),
+                ])),
+                ..Default::default()
+            },
+            ..Default::default()
+        })
+        .insert(Playing);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,8 @@ use bevy_ecs::prelude::SystemSet;
 pub use components::*;
 pub use systems::ParticleSystemLabel;
 use systems::{
-    particle_cleanup, particle_color, particle_lifetime, particle_spawner, particle_transform,
+    particle_cleanup, particle_lifetime, particle_spawner, particle_sprite_color,
+    particle_texture_atlas_color, particle_transform,
 };
 pub use values::*;
 
@@ -98,7 +99,8 @@ impl Plugin for ParticleSystemPlugin {
                 .label(ParticleSystemLabel::ParticleSystem)
                 .with_system(particle_spawner)
                 .with_system(particle_lifetime)
-                .with_system(particle_color)
+                .with_system(particle_sprite_color)
+                .with_system(particle_texture_atlas_color)
                 .with_system(particle_transform)
                 .with_system(particle_cleanup),
         );

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,9 +1,0 @@
-use bevy::prelude::Plugin;
-
-use crate::{
-    systems::{
-        partcle_spawner, particle_cleanup, particle_color, particle_lifetime, particle_transform,
-    },
-    TimeScale,
-};
-

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -274,7 +274,23 @@ pub(crate) fn particle_lifetime(
     });
 }
 
-pub(crate) fn particle_color(mut particle_query: Query<(&Particle, &Lifetime, &mut Sprite)>) {
+pub(crate) fn particle_sprite_color(
+    mut particle_query: Query<(&Particle, &Lifetime, &mut Sprite)>,
+) {
+    particle_query.par_for_each_mut(512, |(particle, lifetime, mut sprite)| {
+        match &particle.color {
+            ColorOverTime::Constant(color) => sprite.color = *color,
+            ColorOverTime::Gradient(gradient) => {
+                let pct = lifetime.0 / particle.max_lifetime;
+                sprite.color = gradient.get_color(pct);
+            }
+        }
+    });
+}
+
+pub(crate) fn particle_texture_atlas_color(
+    mut particle_query: Query<(&Particle, &Lifetime, &mut TextureAtlasSprite)>,
+) {
     particle_query.par_for_each_mut(512, |(particle, lifetime, mut sprite)| {
         match &particle.color {
             ColorOverTime::Constant(color) => sprite.color = *color,


### PR DESCRIPTION
Adds a second system to look for particles that use a `TextureAtlasSprite` for color changes. 

Closes #29 