### PR TITLE
Create enum EmitterShape to allow for emitters other than circles

### DIFF
--- a/examples/directional.rs
+++ b/examples/directional.rs
@@ -36,11 +36,13 @@ fn startup_system(mut commands: Commands, asset_server: Res<AssetServer>) {
             particle_system: ParticleSystem {
                 texture: ParticleTexture::Sprite(asset_server.load("arrow.png")),
                 spawn_rate_per_second: 25.0.into(),
-                spawn_radius: 10.0.into(),
                 initial_speed: JitteredValue::jittered(70.0, -3.0..3.0),
                 lifetime: JitteredValue::jittered(5.0, -1.0..1.0),
-                emitter_shape: std::f32::consts::PI,
-                emitter_angle: std::f32::consts::PI / 2.0,
+                emitter_shape: bevy_particle_systems::EmitterShape::CircleSegment {
+                    radius: 10.0.into(),
+                    opening_angle: std::f32::consts::PI,
+                    direction_angle: std::f32::consts::PI / 2.0,
+                },
                 looping: true,
                 scale: 0.07.into(),
                 system_duration_seconds: 5.0,

--- a/examples/local_space.rs
+++ b/examples/local_space.rs
@@ -39,8 +39,11 @@ fn startup_system(mut commands: Commands, asset_server: Res<AssetServer>) {
         .spawn(ParticleSystemBundle {
             particle_system: ParticleSystem {
                 max_particles: 500,
-                emitter_shape: std::f32::consts::PI * 0.25,
-                emitter_angle: 0.0,
+                emitter_shape: bevy_particle_systems::EmitterShape::CircleSegment {
+                    opening_angle: std::f32::consts::PI * 0.25,
+                    direction_angle: 0.0,
+                    radius: 0.0.into(),
+                },
                 texture: ParticleTexture::Sprite(asset_server.load("px.png")),
                 spawn_rate_per_second: 35.0.into(),
                 initial_speed: JitteredValue::jittered(25.0, 0.0..5.0),
@@ -67,8 +70,11 @@ fn startup_system(mut commands: Commands, asset_server: Res<AssetServer>) {
         .spawn(ParticleSystemBundle {
             particle_system: ParticleSystem {
                 max_particles: 500,
-                emitter_shape: std::f32::consts::PI * 0.25,
-                emitter_angle: std::f32::consts::PI,
+                emitter_shape: bevy_particle_systems::EmitterShape::CircleSegment {
+                    opening_angle: std::f32::consts::PI * 0.25,
+                    direction_angle: std::f32::consts::PI,
+                    radius: 0.0.into(),
+                },
                 texture: ParticleTexture::Sprite(asset_server.load("px.png")),
                 spawn_rate_per_second: 35.0.into(),
                 initial_speed: JitteredValue::jittered(25.0, 0.0..5.0),

--- a/examples/shape_emitter.rs
+++ b/examples/shape_emitter.rs
@@ -1,0 +1,96 @@
+use bevy::{
+    diagnostic::{EntityCountDiagnosticsPlugin, FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
+    prelude::{App, Camera2dBundle, ClearColor, Color, Commands, Res, Transform},
+    window::{PresentMode, WindowDescriptor, WindowPlugin},
+    DefaultPlugins,
+};
+use bevy_app::PluginGroup;
+use bevy_asset::AssetServer;
+
+use bevy_particle_systems::{
+    ColorOverTime, ColorPoint, EmitterShape, Gradient, JitteredValue, ParticleSystem,
+    ParticleSystemBundle, ParticleSystemPlugin, ParticleTexture, Playing,
+};
+
+fn main() {
+    App::new()
+        .insert_resource(ClearColor(Color::BLACK))
+        .add_plugin(EntityCountDiagnosticsPlugin)
+        .add_plugin(FrameTimeDiagnosticsPlugin::default())
+        .add_plugin(LogDiagnosticsPlugin::default())
+        .add_plugins(DefaultPlugins.set(WindowPlugin {
+            window: WindowDescriptor {
+                present_mode: PresentMode::AutoNoVsync,
+                ..Default::default()
+            },
+            ..Default::default()
+        }))
+        .add_plugin(ParticleSystemPlugin::default()) // <-- Add the plugin
+        .add_startup_system(startup_system)
+        .run();
+}
+
+fn startup_system(mut commands: Commands, asset_server: Res<AssetServer>) {
+    commands.spawn(Camera2dBundle::default());
+
+    commands
+        .spawn(ParticleSystemBundle {
+            particle_system: ParticleSystem {
+                max_particles: 50_000,
+                texture: ParticleTexture::Sprite(asset_server.load("arrow.png")),
+                spawn_rate_per_second: 10.0.into(),
+                initial_speed: JitteredValue::jittered(70.0, -3.0..3.0),
+                lifetime: JitteredValue::jittered(10.0, -2.0..2.0),
+                color: ColorOverTime::Gradient(Gradient::new(vec![
+                    ColorPoint::new(Color::PURPLE, 0.0),
+                    ColorPoint::new(Color::RED, 0.5),
+                    ColorPoint::new(Color::rgba(0.0, 0.0, 1.0, 0.0), 1.0),
+                ])),
+                emitter_shape: EmitterShape::Line {
+                    length: 200.0.into(),
+                    angle: std::f32::consts::FRAC_PI_4.into(),
+                },
+                looping: true,
+                rotate_to_movement_direction: true,
+                initial_rotation: (-90.0_f32).to_radians().into(),
+                system_duration_seconds: 10.0,
+                max_distance: Some(300.0),
+                scale: 0.07.into(),
+                ..ParticleSystem::default()
+            },
+            transform: Transform::from_xyz(0.0, -200.0, 0.0),
+            ..ParticleSystemBundle::default()
+        })
+        .insert(Playing);
+
+    commands
+        .spawn(ParticleSystemBundle {
+            particle_system: ParticleSystem {
+                max_particles: 50_000,
+                texture: ParticleTexture::Sprite(asset_server.load("arrow.png")),
+                spawn_rate_per_second: 10.0.into(),
+                initial_speed: JitteredValue::jittered(70.0, -3.0..3.0),
+                lifetime: JitteredValue::jittered(10.0, -2.0..2.0),
+                color: ColorOverTime::Gradient(Gradient::new(vec![
+                    ColorPoint::new(Color::PURPLE, 0.0),
+                    ColorPoint::new(Color::RED, 0.5),
+                    ColorPoint::new(Color::rgba(0.0, 0.0, 1.0, 0.0), 1.0),
+                ])),
+                emitter_shape: bevy_particle_systems::EmitterShape::CircleSegment {
+                    radius: 10.0.into(),
+                    opening_angle: std::f32::consts::PI,
+                    direction_angle: std::f32::consts::FRAC_PI_4.into(),
+                },
+                looping: true,
+                rotate_to_movement_direction: true,
+                initial_rotation: (-90.0_f32).to_radians().into(),
+                system_duration_seconds: 10.0,
+                max_distance: Some(300.0),
+                scale: 0.07.into(),
+                ..ParticleSystem::default()
+            },
+            transform: Transform::from_xyz(0.0, 200.0, 0.0),
+            ..ParticleSystemBundle::default()
+        })
+        .insert(Playing);
+}

--- a/examples/shape_emitter.rs
+++ b/examples/shape_emitter.rs
@@ -47,7 +47,7 @@ fn startup_system(mut commands: Commands, asset_server: Res<AssetServer>) {
                     ColorPoint::new(Color::rgba(0.0, 0.0, 1.0, 0.0), 1.0),
                 ])),
                 emitter_shape: EmitterShape::Line {
-                    length: 200.0.into(),
+                    length: 200.0,
                     angle: std::f32::consts::FRAC_PI_4.into(),
                 },
                 looping: true,
@@ -79,7 +79,7 @@ fn startup_system(mut commands: Commands, asset_server: Res<AssetServer>) {
                 emitter_shape: bevy_particle_systems::EmitterShape::CircleSegment {
                     radius: 10.0.into(),
                     opening_angle: std::f32::consts::PI,
-                    direction_angle: std::f32::consts::FRAC_PI_4.into(),
+                    direction_angle: std::f32::consts::FRAC_PI_4,
                 },
                 looping: true,
                 rotate_to_movement_direction: true,

--- a/examples/time_scaling.rs
+++ b/examples/time_scaling.rs
@@ -30,8 +30,11 @@ fn startup_system(mut commands: Commands, asset_server: Res<AssetServer>) {
         .spawn(ParticleSystemBundle {
             particle_system: ParticleSystem {
                 max_particles: 500,
-                emitter_shape: std::f32::consts::PI * 0.25,
-                emitter_angle: 0.0,
+                emitter_shape: bevy_particle_systems::EmitterShape::CircleSegment {
+                    direction_angle: 0.0,
+                    opening_angle: std::f32::consts::PI * 0.25,
+                    radius: 0.0.into(),
+                },
                 texture: ParticleTexture::Sprite(asset_server.load("px.png")),
                 spawn_rate_per_second: 35.0.into(),
                 initial_speed: JitteredValue::jittered(25.0, 0.0..5.0),
@@ -58,8 +61,11 @@ fn startup_system(mut commands: Commands, asset_server: Res<AssetServer>) {
         .spawn(ParticleSystemBundle {
             particle_system: ParticleSystem {
                 max_particles: 500,
-                emitter_shape: std::f32::consts::PI * 0.25,
-                emitter_angle: std::f32::consts::PI,
+                emitter_shape: bevy_particle_systems::EmitterShape::CircleSegment {
+                    opening_angle: std::f32::consts::PI * 0.25,
+                    direction_angle: std::f32::consts::PI,
+                    radius: 0.0.into(),
+                },
                 texture: ParticleTexture::Sprite(asset_server.load("px.png")),
                 spawn_rate_per_second: 35.0.into(),
                 initial_speed: JitteredValue::jittered(25.0, 0.0..5.0),

--- a/src/components.rs
+++ b/src/components.rs
@@ -8,7 +8,10 @@ use bevy_render::prelude::{Image, VisibilityBundle};
 use bevy_sprite::TextureAtlas;
 use bevy_transform::prelude::{GlobalTransform, Transform};
 
-use crate::values::{ColorOverTime, JitteredValue, RandomValue, ValueOverTime};
+use crate::{
+    values::{ColorOverTime, JitteredValue, RandomValue, ValueOverTime},
+    EmitterShape,
+};
 
 /// Defines a burst of a specified number of particles at the given time in a running particle system.
 ///
@@ -85,24 +88,8 @@ pub struct ParticleSystem {
     /// This uses a [`ValueOverTime`] so that the spawn rate can vary over the lifetime of the system.
     pub spawn_rate_per_second: ValueOverTime,
 
-    /// The radius around the particle systems location that particles will spawn in.
-    ///
-    /// Setting this to zero will make all particles start at the same position.
-    /// Setting this to a non-jittered constant will make particles spawn exactly that distance away from the
-    /// center position. Jitter will allow particles to spawn in a range.
-    pub spawn_radius: JitteredValue,
-
-    /// The shape of the emitter, defined in radian.
-    ///
-    /// The default is [`std::f32::consts::TAU`], which results particles going in all directions in a circle.
-    /// Reducing the value reduces the possible emitting directions. [`std::f32::consts::PI`] will emit particles
-    /// in a semi-circle.
-    pub emitter_shape: f32,
-
-    /// The rotation angle of the emitter, defined in radian.
-    ///
-    /// Zero indicates straight to the right in the X direction. [`std::f32::consts::PI`] indicates straight left in the X direction.
-    pub emitter_angle: f32,
+    /// The shape of the emitter.
+    pub emitter_shape: EmitterShape,
 
     /// The initial movement speed of a particle.
     ///
@@ -187,9 +174,11 @@ impl Default for ParticleSystem {
             texture: ParticleTexture::Sprite(Handle::default()),
             rescale_texture: None,
             spawn_rate_per_second: 5.0.into(),
-            spawn_radius: 0.0.into(),
-            emitter_shape: std::f32::consts::TAU,
-            emitter_angle: 0.0,
+            emitter_shape: EmitterShape::CircleSegment {
+                opening_angle: std::f32::consts::TAU,
+                direction_angle: 0.0,
+                radius: 0.0.into(),
+            },
             initial_speed: 1.0.into(),
             acceleration: 0.0.into(),
             lifetime: 5.0.into(),

--- a/src/values.rs
+++ b/src/values.rs
@@ -46,6 +46,10 @@ pub enum EmitterShape {
 
 impl EmitterShape {
     /// Samples a random starting transform from the Emitter shape
+    ///
+    /// The returned transform describes the position and direction of movement of the newly spawned particle.
+    /// (Note: The actual angle of the new particle might get overridden for a [`ParticleSystem`] e.g if
+    /// `rotate_to_movement_direction` is false.)
     pub fn sample(&self, rng: &mut ThreadRng) -> Transform {
         match self {
             EmitterShape::CircleSegment {

--- a/src/values.rs
+++ b/src/values.rs
@@ -48,7 +48,7 @@ impl EmitterShape {
     /// Samples a random starting transform from the Emitter shape
     ///
     /// The returned transform describes the position and direction of movement of the newly spawned particle.
-    /// (Note: The actual angle of the new particle might get overridden for a [`ParticleSystem`] e.g if
+    /// (Note: The actual angle of the new particle might get overridden for a [`crate::components::ParticleSystem`] e.g if
     /// `rotate_to_movement_direction` is false.)
     pub fn sample(&self, rng: &mut ThreadRng) -> Transform {
         match self {

--- a/src/values.rs
+++ b/src/values.rs
@@ -8,30 +8,7 @@ use bevy_transform::prelude::Transform;
 use rand::seq::SliceRandom;
 use rand::{prelude::ThreadRng, Rng};
 
-/// A value that will be chosen from a set of possible values when read.
-///
-/// ## Examples
-///
-/// ``T`` values can be converted into ``Constant``
-/// [`Range<T>`]s or [`Vec<T>`]s can be converted into ``RandomChoice``
-///
-/// ## Examples
-/// ```
-/// # use bevy_particle_systems::values::{RandomValue};
-/// # use rand;
-///
-/// let mut rng = rand::thread_rng();
-///
-/// // Results in a constant value
-/// let c: RandomValue<usize> = (2).into();
-///
-/// // Results are picked randomly from a range
-/// let r: RandomValue<usize> = (1..3).into();
-///
-/// // Results are picked randomly from a set of values
-/// let v: RandomValue<usize> = vec![0, 2, 4, 8].into();
-/// ```
-
+/// Describes the shape on which new particles get spawned
 #[derive(Debug, Clone, Reflect, FromReflect)]
 pub enum EmitterShape {
     /// A oriented segment of a circle at a given radius
@@ -95,6 +72,29 @@ impl EmitterShape {
     }
 }
 
+/// A value that will be chosen from a set of possible values when read.
+///
+/// ## Examples
+///
+/// ``T`` values can be converted into ``Constant``
+/// [`Range<T>`]s or [`Vec<T>`]s can be converted into ``RandomChoice``
+///
+/// ## Examples
+/// ```
+/// # use bevy_particle_systems::values::{RandomValue};
+/// # use rand;
+///
+/// let mut rng = rand::thread_rng();
+///
+/// // Results in a constant value
+/// let c: RandomValue<usize> = (2).into();
+///
+/// // Results are picked randomly from a range
+/// let r: RandomValue<usize> = (1..3).into();
+///
+/// // Results are picked randomly from a set of values
+/// let v: RandomValue<usize> = vec![0, 2, 4, 8].into();
+/// ```
 #[derive(Debug, Clone, Reflect, FromReflect)]
 pub enum RandomValue<T: Reflect + Clone + FromReflect> {
     /// A constant value

--- a/src/values.rs
+++ b/src/values.rs
@@ -1,8 +1,10 @@
 //! Different value types and controls used in particle systems.
 use std::ops::Range;
 
+use bevy_math::{vec3, Quat, Vec3};
 use bevy_reflect::{FromReflect, Reflect};
 use bevy_render::prelude::Color;
+use bevy_transform::prelude::Transform;
 use rand::seq::SliceRandom;
 use rand::{prelude::ThreadRng, Rng};
 
@@ -29,6 +31,69 @@ use rand::{prelude::ThreadRng, Rng};
 /// // Results are picked randomly from a set of values
 /// let v: RandomValue<usize> = vec![0, 2, 4, 8].into();
 /// ```
+
+#[derive(Debug, Clone, Reflect, FromReflect)]
+pub enum EmitterShape {
+    /// A oriented segment of a circle at a given radius
+    CircleSegment {
+        /// The shape of the emitter, defined in radian.
+        ///
+        /// The default is [`std::f32::consts::TAU`], which results particles going in all directions in a circle.
+        /// Reducing the value reduces the possible emitting directions. [`std::f32::consts::PI`] will emit particles
+        /// in a semi-circle.
+        opening_angle: f32,
+
+        /// The rotation angle of the emitter, defined in radian.
+        ///
+        /// Zero indicates straight to the right in the X direction. [`std::f32::consts::PI`] indicates straight left in the X direction.
+        direction_angle: f32,
+
+        /// The radius around the particle systems location that particles will spawn in.
+        ///
+        /// Setting this to zero will make all particles start at the same position.
+        /// Setting this to a non-jittered constant will make particles spawn exactly that distance away from the
+        /// center position. Jitter will allow particles to spawn in a range.
+        radius: JitteredValue,
+    },
+    /// Emit particles from a 2d line at an angle
+    Line {
+        /// The lenth of the line
+        length: f32,
+
+        /// The rotation angle of the emitter, defined in radian.
+        ///
+        /// Zero indicates straight to the right in the +X direction. [`std::f32::consts::PI`] indicates straight left in the -X direction.
+        angle: JitteredValue,
+    },
+}
+
+impl EmitterShape {
+    /// Samples a random starting transform from the Emitter shape
+    pub fn sample(&self, rng: &mut ThreadRng) -> Transform {
+        match self {
+            EmitterShape::CircleSegment {
+                opening_angle,
+                radius,
+                direction_angle,
+            } => {
+                let radian: f32 = rng.gen_range(-0.5..0.5) * opening_angle + direction_angle;
+                let direction = Vec3::new(radian.cos(), radian.sin(), 0.0);
+
+                let delta = direction * radius.get_value(rng);
+                Transform::from_translation(delta).with_rotation(Quat::from_rotation_z(radian))
+            }
+            EmitterShape::Line { length, angle } => {
+                let angle = angle.get_value(rng);
+                let distance: f32 = rng.gen_range(-0.5..0.5) * length;
+
+                let rotation = Quat::from_rotation_z(angle);
+
+                Transform::from_translation(rotation * vec3(0.0, distance, 0.0))
+                    .with_rotation(rotation)
+            }
+        }
+    }
+}
 
 #[derive(Debug, Clone, Reflect, FromReflect)]
 pub enum RandomValue<T: Reflect + Clone + FromReflect> {


### PR DESCRIPTION
I quickly threw this together for a project of mine, and thought I could as well ask if this is something that could be integrated into the upstream library.

I ran into a situation where I needed particles to be emitted from a line (think Clouds in the background e.g) and found no easy way to do this with this library, so I bundled the three `spawn_radius`, `emitter_shape` and `emitter_angle` properties of the `ParticleSystem` together into an enum `EmitterShape::CircleSegment`. Another variant of this enum is `EmitterShape::Line` which has similar fields that describe a line with a given length - possibly at an angle. 

This enum has an impl with the `sample` function, which returns a random point on the shape of the emitter, which gets used by the `particle_spawner` system to determine the position and orientation of a newly spawned particle.

I also updated all the examples to account for this (breaking) change.