### PR TITLE
Optimize gradients and transforms

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ repository = "https://github.com/abnormalbrain/bevy_particle_systems"
 keywords = ["game", "gamedev", "bevy"]
 categories = ["game-development"]
 
+[profile.release]
+debug = true
+
 [dependencies]
 bevy_app = "0.9"
 bevy_asset = "0.9"

--- a/src/components.rs
+++ b/src/components.rs
@@ -240,11 +240,6 @@ pub struct Particle {
     /// This is copied from [`ParticleSystem::use_scaled_time`] on spawn.
     pub use_scaled_time: bool,
 
-    /// The color of this particle over time.
-    ///
-    /// This is copied from [`ParticleSystem::color`] on spawn.
-    pub color: ColorOverTime,
-
     /// The scale or size of this particle over time.
     ///
     /// This is copied from [`ParticleSystem::scale`] on spawn.
@@ -271,7 +266,6 @@ impl Default for Particle {
             max_lifetime: f32::default(),
             max_distance: None,
             use_scaled_time: true,
-            color: ColorOverTime::default(),
             scale: 1.0.into(),
             rotation_speed: 0.0,
             acceleration: 0.0.into(),
@@ -279,6 +273,15 @@ impl Default for Particle {
         }
     }
 }
+
+/// Holds an individual particles color descriptor.
+/// 
+/// This is separated into its own component because the [`ColorOverTime`]
+/// is used mutably in the case of Gradients to improve performance.
+/// 
+/// Its initial value on particle spawn is copied from [`ParticleSystem::color`]
+#[derive(Debug, Component, Default)]
+pub struct ParticleColor(pub ColorOverTime);
 
 /// Contains how long a particle has been alive, in seconds.
 #[derive(Debug, Component, Default)]
@@ -397,4 +400,5 @@ pub(crate) struct ParticleBundle {
     pub speed: Speed,
     pub direction: Direction,
     pub distance: DistanceTraveled,
+    pub color: ParticleColor,
 }

--- a/src/components.rs
+++ b/src/components.rs
@@ -275,10 +275,10 @@ impl Default for Particle {
 }
 
 /// Holds an individual particles color descriptor.
-/// 
+///
 /// This is separated into its own component because the [`ColorOverTime`]
 /// is used mutably in the case of Gradients to improve performance.
-/// 
+///
 /// Its initial value on particle spawn is copied from [`ParticleSystem::color`]
 #[derive(Debug, Component, Default)]
 pub struct ParticleColor(pub ColorOverTime);

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -283,28 +283,28 @@ pub(crate) fn particle_lifetime(
 }
 
 pub(crate) fn particle_sprite_color(
-    mut particle_query: Query<(&Particle, &Lifetime, &mut Sprite)>,
+    mut particle_query: Query<(&mut Particle, &Lifetime, &mut Sprite)>,
 ) {
-    particle_query.par_for_each_mut(512, |(particle, lifetime, mut sprite)| {
-        match &particle.color {
+    particle_query.par_for_each_mut(512, |(mut particle, lifetime, mut sprite)| {
+        let pct = lifetime.0 / particle.max_lifetime;
+        match &mut particle.color {
             ColorOverTime::Constant(color) => sprite.color = *color,
             ColorOverTime::Gradient(gradient) => {
-                let pct = lifetime.0 / particle.max_lifetime;
-                sprite.color = gradient.get_color(pct);
+                sprite.color = gradient.get_color_mut(pct);
             }
         }
     });
 }
 
 pub(crate) fn particle_texture_atlas_color(
-    mut particle_query: Query<(&Particle, &Lifetime, &mut TextureAtlasSprite)>,
+    mut particle_query: Query<(&mut Particle, &Lifetime, &mut TextureAtlasSprite)>,
 ) {
-    particle_query.par_for_each_mut(512, |(particle, lifetime, mut sprite)| {
-        match &particle.color {
+    particle_query.par_for_each_mut(512, |(mut particle, lifetime, mut sprite)| {
+        let pct = lifetime.0 / particle.max_lifetime;
+        match &mut particle.color {
             ColorOverTime::Constant(color) => sprite.color = *color,
             ColorOverTime::Gradient(gradient) => {
-                let pct = lifetime.0 / particle.max_lifetime;
-                sprite.color = gradient.get_color(pct);
+                sprite.color = gradient.get_color_mut(pct);
             }
         }
     });

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -10,8 +10,8 @@ use rand::prelude::*;
 
 use crate::{
     components::{
-        BurstIndex, Direction, Lifetime, Particle, ParticleBundle, ParticleCount, ParticleSpace, ParticleColor,
-        ParticleSystem, Playing, RunningState, Speed,
+        BurstIndex, Direction, Lifetime, Particle, ParticleBundle, ParticleColor, ParticleCount,
+        ParticleSpace, ParticleSystem, Playing, RunningState, Speed,
     },
     values::ColorOverTime,
     DistanceTraveled, ParticleTexture,
@@ -285,29 +285,40 @@ pub(crate) fn particle_lifetime(
 pub(crate) fn particle_sprite_color(
     mut particle_query: Query<(&Particle, &mut ParticleColor, &Lifetime, &mut Sprite)>,
 ) {
-    particle_query.par_for_each_mut(512, |(particle, mut particle_color, lifetime, mut sprite)| {
-        let pct = lifetime.0 / particle.max_lifetime;
-        match &mut particle_color.0 {
-            ColorOverTime::Constant(color) => sprite.color = *color,
-            ColorOverTime::Gradient(gradient) => {
-                sprite.color = gradient.get_color_mut(pct);
+    particle_query.par_for_each_mut(
+        512,
+        |(particle, mut particle_color, lifetime, mut sprite)| {
+            let pct = lifetime.0 / particle.max_lifetime;
+            match &mut particle_color.0 {
+                ColorOverTime::Constant(color) => sprite.color = *color,
+                ColorOverTime::Gradient(gradient) => {
+                    sprite.color = gradient.get_color_mut(pct);
+                }
             }
-        }
-    });
+        },
+    );
 }
 
 pub(crate) fn particle_texture_atlas_color(
-    mut particle_query: Query<(&Particle, &mut ParticleColor, &Lifetime, &mut TextureAtlasSprite)>,
+    mut particle_query: Query<(
+        &Particle,
+        &mut ParticleColor,
+        &Lifetime,
+        &mut TextureAtlasSprite,
+    )>,
 ) {
-    particle_query.par_for_each_mut(512, |(particle, mut particle_color, lifetime, mut sprite)| {
-        let pct = lifetime.0 / particle.max_lifetime;
-        match &mut particle_color.0 {
-            ColorOverTime::Constant(color) => sprite.color = *color,
-            ColorOverTime::Gradient(gradient) => {
-                sprite.color = gradient.get_color_mut(pct);
+    particle_query.par_for_each_mut(
+        512,
+        |(particle, mut particle_color, lifetime, mut sprite)| {
+            let pct = lifetime.0 / particle.max_lifetime;
+            match &mut particle_color.0 {
+                ColorOverTime::Constant(color) => sprite.color = *color,
+                ColorOverTime::Gradient(gradient) => {
+                    sprite.color = gradient.get_color_mut(pct);
+                }
             }
-        }
-    });
+        },
+    );
 }
 
 pub(crate) fn particle_transform(

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -10,7 +10,7 @@ use rand::prelude::*;
 
 use crate::{
     components::{
-        BurstIndex, Direction, Lifetime, Particle, ParticleBundle, ParticleCount, ParticleSpace,
+        BurstIndex, Direction, Lifetime, Particle, ParticleBundle, ParticleCount, ParticleSpace, ParticleColor,
         ParticleSystem, Playing, RunningState, Speed,
     },
     values::ColorOverTime,
@@ -154,7 +154,6 @@ pub fn particle_spawner(
                             max_lifetime: particle_system.lifetime.get_value(&mut rng),
                             max_distance: particle_system.max_distance,
                             use_scaled_time: particle_system.use_scaled_time,
-                            color: particle_system.color.clone(),
                             scale: particle_system.scale.clone(),
                             rotation_speed: particle_system.rotation_speed.get_value(&mut rng),
                             acceleration: particle_system.acceleration.clone(),
@@ -169,6 +168,7 @@ pub fn particle_spawner(
                             dist_squared: 0.0,
                             from: spawn_point.translation,
                         },
+                        color: ParticleColor(particle_system.color.clone()),
                         ..ParticleBundle::default()
                     });
 
@@ -211,7 +211,6 @@ pub fn particle_spawner(
                                 max_lifetime: particle_system.lifetime.get_value(&mut rng),
                                 max_distance: particle_system.max_distance,
                                 use_scaled_time: particle_system.use_scaled_time,
-                                color: particle_system.color.clone(),
                                 scale: particle_system.scale.clone(),
                                 rotation_speed: particle_system.rotation_speed.get_value(&mut rng),
                                 acceleration: particle_system.acceleration.clone(),
@@ -226,6 +225,7 @@ pub fn particle_spawner(
                                 dist_squared: 0.0,
                                 from: spawn_point.translation,
                             },
+                            color: ParticleColor(particle_system.color.clone()),
                             ..ParticleBundle::default()
                         });
 
@@ -283,11 +283,11 @@ pub(crate) fn particle_lifetime(
 }
 
 pub(crate) fn particle_sprite_color(
-    mut particle_query: Query<(&mut Particle, &Lifetime, &mut Sprite)>,
+    mut particle_query: Query<(&Particle, &mut ParticleColor, &Lifetime, &mut Sprite)>,
 ) {
-    particle_query.par_for_each_mut(512, |(mut particle, lifetime, mut sprite)| {
+    particle_query.par_for_each_mut(512, |(particle, mut particle_color, lifetime, mut sprite)| {
         let pct = lifetime.0 / particle.max_lifetime;
-        match &mut particle.color {
+        match &mut particle_color.0 {
             ColorOverTime::Constant(color) => sprite.color = *color,
             ColorOverTime::Gradient(gradient) => {
                 sprite.color = gradient.get_color_mut(pct);
@@ -297,11 +297,11 @@ pub(crate) fn particle_sprite_color(
 }
 
 pub(crate) fn particle_texture_atlas_color(
-    mut particle_query: Query<(&mut Particle, &Lifetime, &mut TextureAtlasSprite)>,
+    mut particle_query: Query<(&Particle, &mut ParticleColor, &Lifetime, &mut TextureAtlasSprite)>,
 ) {
-    particle_query.par_for_each_mut(512, |(mut particle, lifetime, mut sprite)| {
+    particle_query.par_for_each_mut(512, |(particle, mut particle_color, lifetime, mut sprite)| {
         let pct = lifetime.0 / particle.max_lifetime;
-        match &mut particle.color {
+        match &mut particle_color.0 {
             ColorOverTime::Constant(color) => sprite.color = *color,
             ColorOverTime::Gradient(gradient) => {
                 sprite.color = gradient.get_color_mut(pct);

--- a/src/values.rs
+++ b/src/values.rs
@@ -345,12 +345,12 @@ impl ColorPoint {
 /// one at `0.0` and one at `1.0`.
 ///
 /// Computing the gradient without state is a linear operation and can add up to be
-/// somewhat expensive. [`Gradient::get_color_mut`] can be used in these scenarios to potential
+/// somewhat expensive. [`Gradient::get_color_mut`] can be used in these scenarios to potentialy
 /// improve performance, as long as the particular gradient only moves forward in time. This
 /// will use an `index_hint` state to skip to where the previous call was in gradient detection.
 ///
 /// If most or all of the gradients are only two components, it is likely better to use [`Gradient::get_color`]
-/// rather than [`Gradient::get_color_mut`], as both will take the same shortcuts, but [`Gradient::get_color`] is does not
+/// rather than [`Gradient::get_color_mut`], as both will take the same shortcuts, but [`Gradient::get_color`] does not
 /// require a mutable borrow and therefore can be used in parallel with other systems.
 ///
 /// ## Examples


### PR DESCRIPTION
Adds state tracking to particle gradients, which allows gradients with more than two points to reduce iterations substantially.

For the `basic` demo, this reduced time computing particle color by about 33%.

![image](https://user-images.githubusercontent.com/102993888/216783108-a4c8ee94-c42a-4efb-8a55-51d2db8a3053.png)

The inlining of `lerp` made transform computations quite about 22% faster in the same test.

![image](https://user-images.githubusercontent.com/102993888/216783170-93da7f96-4569-4aa1-8110-f66243388696.png)
