### PR TITLE
Implement `From<Range<f32>>` for `JitteredValue`

### DIFF
--- a/src/values.rs
+++ b/src/values.rs
@@ -209,7 +209,7 @@ impl JitteredValue {
         }
     }
 
-    /// Create a new ``JitteredValue`` with a value centered withing the jitter range.
+    /// Create a new ``JitteredValue`` with a value centered within the jitter range.
     pub fn centered_range(range: Range<f32>) -> Self {
         let mid = (range.start + range.end) / 2.;
         let half_width = (range.end - range.start) / 2.;

--- a/src/values.rs
+++ b/src/values.rs
@@ -209,6 +209,18 @@ impl JitteredValue {
         }
     }
 
+    /// Create a new ``JitteredValue`` with a value centered withing the jitter range.
+    pub fn centered_range(range: Range<f32>) -> Self {
+        let mid = (range.start + range.end) / 2.;
+        let half_width = (range.end - range.start) / 2.;
+        let start = mid - half_width;
+        let end = mid + half_width;
+        Self {
+            value: mid,
+            jitter_range: Some(start..end),
+        }
+    }
+
     /// Create a new ``JitteredValue`` from an existing one with the specified jitter range.
     pub const fn with_jitter(&self, jitter_range: Range<f32>) -> Self {
         Self {
@@ -229,6 +241,12 @@ impl JitteredValue {
 impl From<f32> for JitteredValue {
     fn from(f: f32) -> Self {
         JitteredValue::new(f)
+    }
+}
+
+impl From<Range<f32>> for JitteredValue {
+    fn from(range: Range<f32>) -> Self {
+        JitteredValue::centered_range(range)
     }
 }
 


### PR DESCRIPTION
This allows:

    emitter_shape: EmitterShape::CircleSegment {
        radius: (0.0..0.5).into(),
        opening_angle: 0.5,
        direction_angle: PI * 3. / 2.,
    },