### PR TITLE
[Breaking Change] Make emitter shapes easier to construct

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ fn spawn_particle_system(mut commands: Commands, asset_server: Res<AssetServer>)
     .spawn(ParticleSystemBundle {
         particle_system: ParticleSystem {
             max_particles: 10_000,
-            texture: ParticuleTexture::Sprite(asset_server.load("my_particle.png")),
+            texture: ParticleTexture::Sprite(asset_server.load("my_particle.png")),
             spawn_rate_per_second: 25.0.into(),
             initial_speed: JitteredValue::jittered(3.0, -1.0..1.0),
             lifetime: JitteredValue::jittered(8.0, -2.0..2.0),

--- a/examples/directional.rs
+++ b/examples/directional.rs
@@ -7,8 +7,8 @@ use bevy::{
 use bevy_app::PluginGroup;
 use bevy_asset::AssetServer;
 use bevy_particle_systems::{
-    CircleSegment, EmitterShape, JitteredValue, ParticleSystem, ParticleSystemBundle,
-    ParticleSystemPlugin, ParticleTexture, Playing,
+    CircleSegment, JitteredValue, ParticleSystem, ParticleSystemBundle, ParticleSystemPlugin,
+    ParticleTexture, Playing,
 };
 
 fn main() {
@@ -38,11 +38,12 @@ fn startup_system(mut commands: Commands, asset_server: Res<AssetServer>) {
                 spawn_rate_per_second: 25.0.into(),
                 initial_speed: JitteredValue::jittered(70.0, -3.0..3.0),
                 lifetime: JitteredValue::jittered(5.0, -1.0..1.0),
-                emitter_shape: EmitterShape::CircleSegment(CircleSegment {
+                emitter_shape: CircleSegment {
                     radius: 10.0.into(),
                     opening_angle: std::f32::consts::PI,
                     direction_angle: std::f32::consts::PI / 2.0,
-                }),
+                }
+                .into(),
                 looping: true,
                 scale: 0.07.into(),
                 system_duration_seconds: 5.0,

--- a/examples/directional.rs
+++ b/examples/directional.rs
@@ -7,8 +7,8 @@ use bevy::{
 use bevy_app::PluginGroup;
 use bevy_asset::AssetServer;
 use bevy_particle_systems::{
-    JitteredValue, ParticleSystem, ParticleSystemBundle, ParticleSystemPlugin, ParticleTexture,
-    Playing,
+    CircleSegment, EmitterShape, JitteredValue, ParticleSystem, ParticleSystemBundle,
+    ParticleSystemPlugin, ParticleTexture, Playing,
 };
 
 fn main() {
@@ -38,11 +38,11 @@ fn startup_system(mut commands: Commands, asset_server: Res<AssetServer>) {
                 spawn_rate_per_second: 25.0.into(),
                 initial_speed: JitteredValue::jittered(70.0, -3.0..3.0),
                 lifetime: JitteredValue::jittered(5.0, -1.0..1.0),
-                emitter_shape: bevy_particle_systems::EmitterShape::CircleSegment {
+                emitter_shape: EmitterShape::CircleSegment(CircleSegment {
                     radius: 10.0.into(),
                     opening_angle: std::f32::consts::PI,
                     direction_angle: std::f32::consts::PI / 2.0,
-                },
+                }),
                 looping: true,
                 scale: 0.07.into(),
                 system_duration_seconds: 5.0,

--- a/examples/local_space.rs
+++ b/examples/local_space.rs
@@ -12,8 +12,8 @@ use bevy_math::Quat;
 use bevy_time::Time;
 
 use bevy_particle_systems::{
-    ColorOverTime, ColorPoint, Gradient, JitteredValue, ParticleSpace, ParticleSystem,
-    ParticleSystemBundle, ParticleSystemPlugin, ParticleTexture, Playing,
+    CircleSegment, ColorOverTime, ColorPoint, EmitterShape, Gradient, JitteredValue, ParticleSpace,
+    ParticleSystem, ParticleSystemBundle, ParticleSystemPlugin, ParticleTexture, Playing,
 };
 
 #[derive(Debug, Component)]
@@ -39,11 +39,10 @@ fn startup_system(mut commands: Commands, asset_server: Res<AssetServer>) {
         .spawn(ParticleSystemBundle {
             particle_system: ParticleSystem {
                 max_particles: 500,
-                emitter_shape: bevy_particle_systems::EmitterShape::CircleSegment {
+                emitter_shape: EmitterShape::CircleSegment(CircleSegment {
                     opening_angle: std::f32::consts::PI * 0.25,
-                    direction_angle: 0.0,
-                    radius: 0.0.into(),
-                },
+                    ..Default::default()
+                }),
                 texture: ParticleTexture::Sprite(asset_server.load("px.png")),
                 spawn_rate_per_second: 35.0.into(),
                 initial_speed: JitteredValue::jittered(25.0, 0.0..5.0),
@@ -70,11 +69,11 @@ fn startup_system(mut commands: Commands, asset_server: Res<AssetServer>) {
         .spawn(ParticleSystemBundle {
             particle_system: ParticleSystem {
                 max_particles: 500,
-                emitter_shape: bevy_particle_systems::EmitterShape::CircleSegment {
+                emitter_shape: EmitterShape::CircleSegment(CircleSegment {
                     opening_angle: std::f32::consts::PI * 0.25,
                     direction_angle: std::f32::consts::PI,
-                    radius: 0.0.into(),
-                },
+                    ..Default::default()
+                }),
                 texture: ParticleTexture::Sprite(asset_server.load("px.png")),
                 spawn_rate_per_second: 35.0.into(),
                 initial_speed: JitteredValue::jittered(25.0, 0.0..5.0),

--- a/examples/local_space.rs
+++ b/examples/local_space.rs
@@ -12,7 +12,7 @@ use bevy_math::Quat;
 use bevy_time::Time;
 
 use bevy_particle_systems::{
-    CircleSegment, ColorOverTime, ColorPoint, EmitterShape, Gradient, JitteredValue, ParticleSpace,
+    CircleSegment, ColorOverTime, ColorPoint, Gradient, JitteredValue, ParticleSpace,
     ParticleSystem, ParticleSystemBundle, ParticleSystemPlugin, ParticleTexture, Playing,
 };
 
@@ -39,10 +39,11 @@ fn startup_system(mut commands: Commands, asset_server: Res<AssetServer>) {
         .spawn(ParticleSystemBundle {
             particle_system: ParticleSystem {
                 max_particles: 500,
-                emitter_shape: EmitterShape::CircleSegment(CircleSegment {
+                emitter_shape: CircleSegment {
                     opening_angle: std::f32::consts::PI * 0.25,
                     ..Default::default()
-                }),
+                }
+                .into(),
                 texture: ParticleTexture::Sprite(asset_server.load("px.png")),
                 spawn_rate_per_second: 35.0.into(),
                 initial_speed: JitteredValue::jittered(25.0, 0.0..5.0),
@@ -69,11 +70,12 @@ fn startup_system(mut commands: Commands, asset_server: Res<AssetServer>) {
         .spawn(ParticleSystemBundle {
             particle_system: ParticleSystem {
                 max_particles: 500,
-                emitter_shape: EmitterShape::CircleSegment(CircleSegment {
+                emitter_shape: CircleSegment {
                     opening_angle: std::f32::consts::PI * 0.25,
                     direction_angle: std::f32::consts::PI,
                     ..Default::default()
-                }),
+                }
+                .into(),
                 texture: ParticleTexture::Sprite(asset_server.load("px.png")),
                 spawn_rate_per_second: 35.0.into(),
                 initial_speed: JitteredValue::jittered(25.0, 0.0..5.0),

--- a/examples/shape_emitter.rs
+++ b/examples/shape_emitter.rs
@@ -8,8 +8,8 @@ use bevy_app::PluginGroup;
 use bevy_asset::AssetServer;
 
 use bevy_particle_systems::{
-    ColorOverTime, ColorPoint, EmitterShape, Gradient, JitteredValue, ParticleSystem,
-    ParticleSystemBundle, ParticleSystemPlugin, ParticleTexture, Playing,
+    CircleSegment, ColorOverTime, ColorPoint, EmitterShape, Gradient, JitteredValue,
+    ParticleSystem, ParticleSystemBundle, ParticleSystemPlugin, ParticleTexture, Playing,
 };
 
 fn main() {
@@ -46,10 +46,7 @@ fn startup_system(mut commands: Commands, asset_server: Res<AssetServer>) {
                     ColorPoint::new(Color::RED, 0.5),
                     ColorPoint::new(Color::rgba(0.0, 0.0, 1.0, 0.0), 1.0),
                 ])),
-                emitter_shape: EmitterShape::Line {
-                    length: 200.0,
-                    angle: std::f32::consts::FRAC_PI_4.into(),
-                },
+                emitter_shape: EmitterShape::line(200.0, std::f32::consts::FRAC_PI_4),
                 looping: true,
                 rotate_to_movement_direction: true,
                 initial_rotation: (-90.0_f32).to_radians().into(),
@@ -76,11 +73,11 @@ fn startup_system(mut commands: Commands, asset_server: Res<AssetServer>) {
                     ColorPoint::new(Color::RED, 0.5),
                     ColorPoint::new(Color::rgba(0.0, 0.0, 1.0, 0.0), 1.0),
                 ])),
-                emitter_shape: bevy_particle_systems::EmitterShape::CircleSegment {
+                emitter_shape: EmitterShape::CircleSegment(CircleSegment {
                     radius: 10.0.into(),
                     opening_angle: std::f32::consts::PI,
                     direction_angle: std::f32::consts::FRAC_PI_4,
-                },
+                }),
                 looping: true,
                 rotate_to_movement_direction: true,
                 initial_rotation: (-90.0_f32).to_radians().into(),

--- a/examples/shape_emitter.rs
+++ b/examples/shape_emitter.rs
@@ -73,11 +73,12 @@ fn startup_system(mut commands: Commands, asset_server: Res<AssetServer>) {
                     ColorPoint::new(Color::RED, 0.5),
                     ColorPoint::new(Color::rgba(0.0, 0.0, 1.0, 0.0), 1.0),
                 ])),
-                emitter_shape: EmitterShape::CircleSegment(CircleSegment {
+                emitter_shape: CircleSegment {
                     radius: 10.0.into(),
                     opening_angle: std::f32::consts::PI,
                     direction_angle: std::f32::consts::FRAC_PI_4,
-                }),
+                }
+                .into(),
                 looping: true,
                 rotate_to_movement_direction: true,
                 initial_rotation: (-90.0_f32).to_radians().into(),

--- a/examples/time_scaling.rs
+++ b/examples/time_scaling.rs
@@ -10,7 +10,7 @@ use bevy::{
 };
 use bevy_asset::AssetServer;
 use bevy_particle_systems::{
-    CircleSegment, ColorOverTime, ColorPoint, EmitterShape, Gradient, JitteredValue, ParticleSpace,
+    CircleSegment, ColorOverTime, ColorPoint, Gradient, JitteredValue, ParticleSpace,
     ParticleSystem, ParticleSystemBundle, ParticleSystemPlugin, ParticleTexture, Playing,
 };
 use bevy_time::Time;
@@ -30,11 +30,12 @@ fn startup_system(mut commands: Commands, asset_server: Res<AssetServer>) {
         .spawn(ParticleSystemBundle {
             particle_system: ParticleSystem {
                 max_particles: 500,
-                emitter_shape: EmitterShape::CircleSegment(CircleSegment {
+                emitter_shape: CircleSegment {
                     direction_angle: 0.0,
                     opening_angle: std::f32::consts::PI * 0.25,
                     radius: 0.0.into(),
-                }),
+                }
+                .into(),
                 texture: ParticleTexture::Sprite(asset_server.load("px.png")),
                 spawn_rate_per_second: 35.0.into(),
                 initial_speed: JitteredValue::jittered(25.0, 0.0..5.0),
@@ -61,11 +62,12 @@ fn startup_system(mut commands: Commands, asset_server: Res<AssetServer>) {
         .spawn(ParticleSystemBundle {
             particle_system: ParticleSystem {
                 max_particles: 500,
-                emitter_shape: EmitterShape::CircleSegment(CircleSegment {
+                emitter_shape: CircleSegment {
                     opening_angle: std::f32::consts::PI * 0.25,
                     direction_angle: std::f32::consts::PI,
                     radius: 0.0.into(),
-                }),
+                }
+                .into(),
                 texture: ParticleTexture::Sprite(asset_server.load("px.png")),
                 spawn_rate_per_second: 35.0.into(),
                 initial_speed: JitteredValue::jittered(25.0, 0.0..5.0),

--- a/examples/time_scaling.rs
+++ b/examples/time_scaling.rs
@@ -10,8 +10,8 @@ use bevy::{
 };
 use bevy_asset::AssetServer;
 use bevy_particle_systems::{
-    ColorOverTime, ColorPoint, Gradient, JitteredValue, ParticleSpace, ParticleSystem,
-    ParticleSystemBundle, ParticleSystemPlugin, ParticleTexture, Playing,
+    CircleSegment, ColorOverTime, ColorPoint, EmitterShape, Gradient, JitteredValue, ParticleSpace,
+    ParticleSystem, ParticleSystemBundle, ParticleSystemPlugin, ParticleTexture, Playing,
 };
 use bevy_time::Time;
 fn main() {
@@ -30,11 +30,11 @@ fn startup_system(mut commands: Commands, asset_server: Res<AssetServer>) {
         .spawn(ParticleSystemBundle {
             particle_system: ParticleSystem {
                 max_particles: 500,
-                emitter_shape: bevy_particle_systems::EmitterShape::CircleSegment {
+                emitter_shape: EmitterShape::CircleSegment(CircleSegment {
                     direction_angle: 0.0,
                     opening_angle: std::f32::consts::PI * 0.25,
                     radius: 0.0.into(),
-                },
+                }),
                 texture: ParticleTexture::Sprite(asset_server.load("px.png")),
                 spawn_rate_per_second: 35.0.into(),
                 initial_speed: JitteredValue::jittered(25.0, 0.0..5.0),
@@ -61,11 +61,11 @@ fn startup_system(mut commands: Commands, asset_server: Res<AssetServer>) {
         .spawn(ParticleSystemBundle {
             particle_system: ParticleSystem {
                 max_particles: 500,
-                emitter_shape: bevy_particle_systems::EmitterShape::CircleSegment {
+                emitter_shape: EmitterShape::CircleSegment(CircleSegment {
                     opening_angle: std::f32::consts::PI * 0.25,
                     direction_angle: std::f32::consts::PI,
                     radius: 0.0.into(),
-                },
+                }),
                 texture: ParticleTexture::Sprite(asset_server.load("px.png")),
                 spawn_rate_per_second: 35.0.into(),
                 initial_speed: JitteredValue::jittered(25.0, 0.0..5.0),

--- a/src/components.rs
+++ b/src/components.rs
@@ -9,7 +9,7 @@ use bevy_sprite::TextureAtlas;
 use bevy_transform::prelude::{GlobalTransform, Transform};
 
 use crate::{
-    values::{ColorOverTime, JitteredValue, RandomValue, ValueOverTime},
+    values::{CircleSegment, ColorOverTime, JitteredValue, RandomValue, ValueOverTime},
     EmitterShape,
 };
 
@@ -174,11 +174,7 @@ impl Default for ParticleSystem {
             texture: ParticleTexture::Sprite(Handle::default()),
             rescale_texture: None,
             spawn_rate_per_second: 5.0.into(),
-            emitter_shape: EmitterShape::CircleSegment {
-                opening_angle: std::f32::consts::TAU,
-                direction_angle: 0.0,
-                radius: 0.0.into(),
-            },
+            emitter_shape: EmitterShape::CircleSegment(CircleSegment::default()),
             initial_speed: 1.0.into(),
             acceleration: 0.0.into(),
             lifetime: 5.0.into(),

--- a/src/components.rs
+++ b/src/components.rs
@@ -9,7 +9,7 @@ use bevy_sprite::TextureAtlas;
 use bevy_transform::prelude::{GlobalTransform, Transform};
 
 use crate::{
-    values::{CircleSegment, ColorOverTime, JitteredValue, RandomValue, ValueOverTime},
+    values::{ColorOverTime, JitteredValue, RandomValue, ValueOverTime},
     EmitterShape,
 };
 
@@ -174,7 +174,7 @@ impl Default for ParticleSystem {
             texture: ParticleTexture::Sprite(Handle::default()),
             rescale_texture: None,
             spawn_rate_per_second: 5.0.into(),
-            emitter_shape: EmitterShape::CircleSegment(CircleSegment::default()),
+            emitter_shape: EmitterShape::default(),
             initial_speed: 1.0.into(),
             acceleration: 0.0.into(),
             lifetime: 5.0.into(),

--- a/src/values.rs
+++ b/src/values.rs
@@ -8,12 +8,12 @@ use bevy_transform::prelude::Transform;
 use rand::seq::SliceRandom;
 use rand::{prelude::ThreadRng, Rng};
 
-/// Describes an oriengted segment of a circle with a given radius.
+/// Describes an oriented segment of a circle with a given radius.
 #[derive(Debug, Clone, Reflect, FromReflect)]
 pub struct CircleSegment {
-    /// The shape of the emitter, defined in radian.
+    /// The shape of the emitter, defined in radians.
     ///
-    /// The default is [`std::f32::consts::TAU`], which results particles going in all directions in a circle.
+    /// The default is `2 * PI`, which results particles going in all directions in a circle.
     /// Reducing the value reduces the possible emitting directions. [`std::f32::consts::PI`] will emit particles
     /// in a semi-circle.
     pub opening_angle: f32,

--- a/src/values.rs
+++ b/src/values.rs
@@ -41,6 +41,12 @@ impl Default for CircleSegment {
     }
 }
 
+impl From<CircleSegment> for EmitterShape {
+    fn from(segment: CircleSegment) -> EmitterShape {
+        EmitterShape::CircleSegment(segment)
+    }
+}
+
 /// Defines a line along which particles will be spawned.
 #[derive(Debug, Clone, Reflect, FromReflect)]
 pub struct Line {
@@ -62,7 +68,29 @@ impl Default for Line {
     }
 }
 
+impl From<Line> for EmitterShape {
+    fn from(line: Line) -> EmitterShape {
+        EmitterShape::Line(line)
+    }
+}
+
 /// Describes the shape on which new particles get spawned
+///
+/// For convenience, these can also be created directly from
+/// [`CircleSegment`] and [`Line`] instances, or using [`EmitterShape::line`] or
+/// [`EmitterShape::circle`]
+///
+/// # Examples
+///
+/// ```rust
+/// # use bevy_particle_systems::values::{CircleSegment, EmitterShape, Line};
+/// # use bevy_particle_systems::ParticleSystem;
+/// let particle_system = ParticleSystem {
+///     emitter_shape: CircleSegment::default().into(),
+///     // ...
+///     ..Default::default()
+/// };
+/// ```
 #[derive(Debug, Clone, Reflect, FromReflect)]
 pub enum EmitterShape {
     /// An oriented segment of a circle with a given radius


### PR DESCRIPTION
Changes emitter shapes to use an inner struct to define properties, so that defaults can be used. Also defines a few convenience functions for creating emitter shapes, and adds `Default` to `EmitterShape` itself.

Closes #36 