### PR TITLE
Add support for jittered initial scale

### DIFF
--- a/src/components.rs
+++ b/src/components.rs
@@ -153,6 +153,13 @@ pub struct ParticleSystem {
     /// This can vary over time and be used to modify alpha as well.
     pub color: ColorOverTime,
 
+    /// The initial scale of a particle.
+    ///
+    /// This value can be constant, or have added jitter to have particles with different sizes
+    ///
+    /// This value is multiplied with scale to produce the final scale.
+    pub initial_scale: JitteredValue,
+
     /// The scale or size of the particle over time.
     ///
     /// Changing this value over time shrinks or grows the particle accordingly.
@@ -219,6 +226,7 @@ impl Default for ParticleSystem {
             velocity_modifiers: vec![],
             lifetime: 5.0.into(),
             color: ColorOverTime::default(),
+            initial_scale: 1.0.into(),
             scale: 1.0.into(),
             initial_rotation: 0.0.into(),
             rotation_speed: 0.0.into(),
@@ -278,6 +286,10 @@ pub struct Particle {
     /// This is copied from [`ParticleSystem::use_scaled_time`] on spawn.
     pub use_scaled_time: bool,
 
+    /// The initial scale of the particle, multiplied with `scale` to produce
+    /// the final scale of the particle.
+    pub initial_scale: f32,
+
     /// The scale or size of this particle over time.
     ///
     /// This is copied from [`ParticleSystem::scale`] on spawn.
@@ -304,6 +316,7 @@ impl Default for Particle {
             max_lifetime: f32::default(),
             max_distance: None,
             use_scaled_time: true,
+            initial_scale: 1.0,
             scale: 1.0.into(),
             rotation_speed: 0.0,
             velocity_modifiers: vec![],

--- a/src/components.rs
+++ b/src/components.rs
@@ -163,6 +163,8 @@ pub struct ParticleSystem {
     /// The scale or size of the particle over time.
     ///
     /// Changing this value over time shrinks or grows the particle accordingly.
+    ///
+    /// Multiplied with [`initial_scale`][`Self::initial_scale`] to produce the final scale.
     pub scale: ValueOverTime,
 
     /// The rotation of a particle around the `z` access at spawn in radian.

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -134,7 +134,8 @@ pub fn particle_spawner(
                 .z_value_override
                 .as_ref()
                 .map_or(0.0, |jittered_value| jittered_value.get_value(&mut rng));
-            let particle_scale = particle_system.scale.at_lifetime_pct(0.0);
+            let initial_scale = particle_system.initial_scale.get_value(&mut rng);
+            let particle_scale = initial_scale * particle_system.scale.at_lifetime_pct(0.0);
             spawn_point.scale = Vec3::new(particle_scale, particle_scale, particle_scale);
 
             if particle_system.rotate_to_movement_direction {
@@ -152,6 +153,7 @@ pub fn particle_spawner(
                             max_lifetime: particle_system.lifetime.get_value(&mut rng),
                             max_distance: particle_system.max_distance,
                             use_scaled_time: particle_system.use_scaled_time,
+                            initial_scale,
                             scale: particle_system.scale.clone(),
                             rotation_speed: particle_system.rotation_speed.get_value(&mut rng),
                             velocity_modifiers: particle_system.velocity_modifiers.clone(),
@@ -212,6 +214,7 @@ pub fn particle_spawner(
                                 max_lifetime: particle_system.lifetime.get_value(&mut rng),
                                 max_distance: particle_system.max_distance,
                                 use_scaled_time: particle_system.use_scaled_time,
+                                initial_scale,
                                 scale: particle_system.scale.clone(),
                                 rotation_speed: particle_system.rotation_speed.get_value(&mut rng),
                                 velocity_modifiers: particle_system.velocity_modifiers.clone(),
@@ -387,7 +390,8 @@ pub(crate) fn particle_transform(
             }
             transform.translation += velocity.0 * delta_time;
 
-            transform.scale = Vec3::splat(particle.scale.at_lifetime_pct(lifetime_pct));
+            transform.scale =
+                Vec3::splat(particle.initial_scale * particle.scale.at_lifetime_pct(lifetime_pct));
             transform.rotate_z(particle.rotation_speed * time.delta_seconds());
 
             distance.dist_squared = transform.translation.distance_squared(distance.from);


### PR DESCRIPTION
Mirrors implementation of `initial_rotation` and `initial_speed`