### PR TITLE
Clamp curves to first/last value

### DIFF
--- a/src/values.rs
+++ b/src/values.rs
@@ -640,8 +640,7 @@ where
 {
     /// Creates a new Curve from given [`CurvePoint`]s.
     ///
-    /// Points should be in sorted, ascending order. There must be at least two points.
-    /// The first point must be at 0.0 and the last at 1.0.
+    /// Points should be in sorted, ascending order.
     ///
     /// This function panics in dev builds if this is not the case.
     pub fn new(points: Vec<CurvePoint<T>>) -> Self {


### PR DESCRIPTION
It's sometimes useful to just specify the end or start of a curve, without having to duplicate the same value twice.

E.g.

```rust
Curve::new(vec![
    CurvePoint::new(1.0, 0.5),
    CurvePoint::new(0.0, 1.0),
]);
```

Is equivalent to:

```rust
Curve::new(vec![
    CurvePoint::new(1.0, 0.0),
    CurvePoint::new(1.0, 0.5),
    CurvePoint::new(0.0, 1.0),
]);
```