### PR TITLE
Update Bevy to 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,25 +14,27 @@ categories = ["game-development"]
 debug = true
 
 [dependencies]
-bevy_app = "0.13"
-bevy_asset = "0.13"
-bevy_ecs = "0.13"
-bevy_hierarchy = "0.13"
-bevy_math = "0.13"
-bevy_render = "0.13"
-bevy_sprite = "0.13"
-bevy_time = "0.13"
-bevy_transform = "0.13"
-bevy_reflect = "0.13"
+bevy_app = "0.14"
+bevy_asset = "0.14"
+bevy_color = "0.14"
+bevy_ecs = "0.14"
+bevy_hierarchy = "0.14"
+bevy_math = "0.14"
+bevy_render = "0.14"
+bevy_sprite = "0.14"
+bevy_time = "0.14"
+bevy_transform = "0.14"
+bevy_reflect = "0.14"
 rand = "0.8"
 
 [dev-dependencies]
-bevy = { version = "0.13", default-features=false, features = [
+bevy = { version = "0.14", default-features = false, features = [
     "bevy_asset",
     "bevy_sprite",
     "bevy_core_pipeline",
+    "bevy_color",
     "png",
     "bevy_winit",
-    "x11"
+    "x11",
 ] }
 approx = "0.5"

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -4,6 +4,7 @@ use bevy::{
     window::{PresentMode, WindowPlugin},
     DefaultPlugins,
 };
+use bevy_color::palettes::css::{PURPLE, RED};
 use bevy_particle_systems::{
     ColorOverTime, Curve, CurvePoint, JitteredValue, ParticleBurst, ParticleSystem,
     ParticleSystemBundle, ParticleSystemPlugin, Playing, VelocityModifier::*,
@@ -42,9 +43,9 @@ fn startup_system(mut commands: Commands, asset_server: Res<AssetServer>) {
                 velocity_modifiers: vec![Drag(0.01.into())],
                 lifetime: JitteredValue::jittered(8.0, -2.0..2.0),
                 color: ColorOverTime::Gradient(Curve::new(vec![
-                    CurvePoint::new(Color::PURPLE, 0.0),
-                    CurvePoint::new(Color::RED, 0.5),
-                    CurvePoint::new(Color::rgba(0.0, 0.0, 1.0, 0.0), 1.0),
+                    CurvePoint::new(PURPLE.into(), 0.0),
+                    CurvePoint::new(RED.into(), 0.5),
+                    CurvePoint::new(Color::srgba(0.0, 0.0, 1.0, 0.0), 1.0),
                 ])),
                 looping: true,
                 system_duration_seconds: 10.0,

--- a/examples/local_space.rs
+++ b/examples/local_space.rs
@@ -9,6 +9,7 @@ use bevy::{
 };
 use bevy_app::{Startup, Update};
 use bevy_asset::AssetServer;
+use bevy_color::palettes::css::{LIME, RED};
 use bevy_math::Quat;
 use bevy_time::Time;
 
@@ -49,8 +50,8 @@ fn startup_system(mut commands: Commands, asset_server: Res<AssetServer>) {
                 initial_speed: JitteredValue::jittered(25.0, 0.0..5.0),
                 lifetime: JitteredValue::jittered(3.0, -2.0..2.0),
                 color: ColorOverTime::Gradient(Curve::new(vec![
-                    CurvePoint::new(Color::RED, 0.0),
-                    CurvePoint::new(Color::rgba(0.0, 0.0, 0.0, 0.0), 1.0),
+                    CurvePoint::new(RED.into(), 0.0),
+                    CurvePoint::new(Color::srgba(0.0, 0.0, 0.0, 0.0), 1.0),
                 ])),
                 looping: true,
                 system_duration_seconds: 10.0,
@@ -80,8 +81,8 @@ fn startup_system(mut commands: Commands, asset_server: Res<AssetServer>) {
                 initial_speed: JitteredValue::jittered(25.0, 0.0..5.0),
                 lifetime: JitteredValue::jittered(3.0, -2.0..2.0),
                 color: ColorOverTime::Gradient(Curve::new(vec![
-                    CurvePoint::new(Color::GREEN, 0.0),
-                    CurvePoint::new(Color::rgba(0.0, 0.0, 0.0, 0.0), 1.0),
+                    CurvePoint::new(LIME.into(), 0.0),
+                    CurvePoint::new(Color::srgba(0.0, 0.0, 0.0, 0.0), 1.0),
                 ])),
                 looping: true,
                 system_duration_seconds: 10.0,

--- a/examples/oneshot.rs
+++ b/examples/oneshot.rs
@@ -2,6 +2,7 @@
 //! automatically despawned when finished.
 
 use bevy::{input::common_conditions::input_just_pressed, prelude::*, window::PrimaryWindow};
+use bevy_color::palettes::css::BLUE;
 use bevy_particle_systems::{
     ParticleBurst, ParticleSystem, ParticleSystemBundle, ParticleSystemPlugin, Playing,
     VelocityModifier,
@@ -48,7 +49,7 @@ fn spawn_particle_systems(
                         VelocityModifier::Drag(0.001.into()),
                         VelocityModifier::Vector(Vec3::new(0.0, -400.0, 0.0).into()),
                     ],
-                    color: (Color::BLUE..Color::rgba(1.0, 0.0, 0.0, 0.0)).into(),
+                    color: (BLUE.into()..Color::srgba(1.0, 0.0, 0.0, 0.0)).into(),
                     bursts: vec![ParticleBurst {
                         time: 0.0,
                         count: 1000,

--- a/examples/shape_emitter.rs
+++ b/examples/shape_emitter.rs
@@ -7,6 +7,7 @@ use bevy::{
 use bevy_app::PluginGroup;
 use bevy_asset::AssetServer;
 
+use bevy_color::palettes::css::{PURPLE, RED};
 use bevy_particle_systems::{
     CircleSegment, ColorOverTime, Curve, CurvePoint, EmitterShape, JitteredValue, ParticleSystem,
     ParticleSystemBundle, ParticleSystemPlugin, Playing,
@@ -44,9 +45,9 @@ fn startup_system(mut commands: Commands, asset_server: Res<AssetServer>) {
                 initial_speed: JitteredValue::jittered(70.0, -3.0..3.0),
                 lifetime: JitteredValue::jittered(3.0, -2.0..2.0),
                 color: ColorOverTime::Gradient(Curve::new(vec![
-                    CurvePoint::new(Color::PURPLE, 0.0),
-                    CurvePoint::new(Color::RED, 0.5),
-                    CurvePoint::new(Color::rgba(0.0, 0.0, 1.0, 0.0), 1.0),
+                    CurvePoint::new(PURPLE.into(), 0.0),
+                    CurvePoint::new(RED.into(), 0.5),
+                    CurvePoint::new(Color::srgba(0.0, 0.0, 1.0, 0.0), 1.0),
                 ])),
                 emitter_shape: EmitterShape::line(200.0, std::f32::consts::FRAC_PI_4),
                 looping: true,
@@ -71,9 +72,9 @@ fn startup_system(mut commands: Commands, asset_server: Res<AssetServer>) {
                 initial_speed: JitteredValue::jittered(70.0, -3.0..3.0),
                 lifetime: JitteredValue::jittered(3.0, -2.0..2.0),
                 color: ColorOverTime::Gradient(Curve::new(vec![
-                    CurvePoint::new(Color::PURPLE, 0.0),
-                    CurvePoint::new(Color::RED, 0.5),
-                    CurvePoint::new(Color::rgba(0.0, 0.0, 1.0, 0.0), 1.0),
+                    CurvePoint::new(PURPLE.into(), 0.0),
+                    CurvePoint::new(RED.into(), 0.5),
+                    CurvePoint::new(Color::srgba(0.0, 0.0, 1.0, 0.0), 1.0),
                 ])),
                 emitter_shape: CircleSegment {
                     radius: 10.0.into(),

--- a/examples/texture_atlas.rs
+++ b/examples/texture_atlas.rs
@@ -10,7 +10,8 @@ use bevy::{
 };
 use bevy_app::{App, PluginGroup, Startup};
 use bevy_asset::{AssetServer, Assets};
-use bevy_math::Vec2;
+use bevy_color::{Gray, Srgba};
+use bevy_math::{UVec2, Vec2};
 use bevy_particle_systems::{
     CircleSegment, ColorOverTime, Curve, CurvePoint, ParticleSystem, ParticleSystemBundle,
     ParticleSystemPlugin, ParticleTexture, Playing,
@@ -33,7 +34,7 @@ fn startup_system(
 ) {
     let projectiles = asset_server.load("gabe-idle-run.png");
     let particle_atlas = atlases.add(TextureAtlasLayout::from_grid(
-        Vec2::new(24.0, 24.0),
+        UVec2::new(24, 24),
         7,
         1,
         None,
@@ -61,10 +62,10 @@ fn startup_system(
                 initial_speed: (150.0..250.0).into(),
                 scale: 8.5.into(),
                 color: ColorOverTime::Gradient(Curve::new(vec![
-                    CurvePoint::new(Color::rgba(1.0, 1.0, 1.0, 0.0), 0.0),
+                    CurvePoint::new(Color::srgba(1.0, 1.0, 1.0, 0.0), 0.0),
                     CurvePoint::new(Color::WHITE, 0.1),
                     CurvePoint::new(Color::WHITE, 0.9),
-                    CurvePoint::new(Color::rgba(1.0, 1.0, 1.0, 0.0), 1.0),
+                    CurvePoint::new(Color::srgba(1.0, 1.0, 1.0, 0.0), 1.0),
                 ])),
                 ..Default::default()
             },
@@ -78,7 +79,7 @@ fn startup_system(
 fn setup_ground(mut commands: Commands) {
     commands.spawn(SpriteBundle {
         sprite: Sprite {
-            color: Color::DARK_GRAY,
+            color: Srgba::gray(0.25).into(),
             custom_size: Some(Vec2 { x: 1000.0, y: 40.0 }),
             ..Default::default()
         },

--- a/examples/time_scaling.rs
+++ b/examples/time_scaling.rs
@@ -10,6 +10,7 @@ use bevy::{
 };
 use bevy_app::{Startup, Update};
 use bevy_asset::AssetServer;
+use bevy_color::palettes::css::{LIME, RED};
 use bevy_particle_systems::{
     CircleSegment, ColorOverTime, Curve, CurvePoint, JitteredValue, ParticleSpace, ParticleSystem,
     ParticleSystemBundle, ParticleSystemPlugin, Playing,
@@ -41,8 +42,8 @@ fn startup_system(mut commands: Commands, asset_server: Res<AssetServer>) {
                 initial_speed: JitteredValue::jittered(25.0, 0.0..5.0),
                 lifetime: JitteredValue::jittered(3.0, -2.0..2.0),
                 color: ColorOverTime::Gradient(Curve::new(vec![
-                    CurvePoint::new(Color::RED, 0.0),
-                    CurvePoint::new(Color::rgba(0.0, 0.0, 0.0, 0.0), 1.0),
+                    CurvePoint::new(RED.into(), 0.0),
+                    CurvePoint::new(Color::srgba(0.0, 0.0, 0.0, 0.0), 1.0),
                 ])),
                 looping: true,
                 system_duration_seconds: 10.0,
@@ -72,8 +73,8 @@ fn startup_system(mut commands: Commands, asset_server: Res<AssetServer>) {
                 initial_speed: JitteredValue::jittered(25.0, 0.0..5.0),
                 lifetime: JitteredValue::jittered(3.0, -2.0..2.0),
                 color: ColorOverTime::Gradient(Curve::new(vec![
-                    CurvePoint::new(Color::GREEN, 0.0),
-                    CurvePoint::new(Color::rgba(0.0, 0.0, 0.0, 0.0), 1.0),
+                    CurvePoint::new(LIME.into(), 0.0),
+                    CurvePoint::new(Color::srgba(0.0, 0.0, 0.0, 0.0), 1.0),
                 ])),
                 looping: true,
                 system_duration_seconds: 10.0,

--- a/examples/velocity_modifiers.rs
+++ b/examples/velocity_modifiers.rs
@@ -14,6 +14,7 @@ use bevy::{
 use bevy_app::Startup;
 use bevy_asset::AssetServer;
 
+use bevy_color::palettes::css::{BLUE, LIME, RED};
 use bevy_particle_systems::{
     CircleSegment, ColorOverTime, Curve, CurvePoint, JitteredValue, Noise2D, ParticleSystem,
     ParticleSystemBundle, ParticleSystemPlugin, Playing, VelocityModifier::*,
@@ -53,7 +54,7 @@ fn startup_system(mut commands: Commands, asset_server: Res<AssetServer>) {
                     Vector(Vec3::new(0.0, 250.0, 0.0).into()),
                 ],
                 lifetime: JitteredValue::jittered(1.5, -0.2..0.2),
-                color: ColorOverTime::Constant(Color::RED),
+                color: ColorOverTime::Constant(RED.into()),
                 scale: 10.0.into(),
                 rotation_speed: 2.0.into(),
                 ..ParticleSystem::default()
@@ -80,7 +81,7 @@ fn startup_system(mut commands: Commands, asset_server: Res<AssetServer>) {
                     Drag(0.01.into()),
                 ],
                 lifetime: JitteredValue::jittered(1.5, -0.2..0.2),
-                color: ColorOverTime::Constant(Color::GREEN),
+                color: ColorOverTime::Constant(LIME.into()),
                 scale: 10.0.into(),
                 rotation_speed: 2.0.into(),
                 ..ParticleSystem::default()
@@ -110,7 +111,7 @@ fn startup_system(mut commands: Commands, asset_server: Res<AssetServer>) {
                     }),
                 ],
                 lifetime: JitteredValue::jittered(2.5, -0.2..0.2),
-                color: ColorOverTime::Constant(Color::BLUE),
+                color: ColorOverTime::Constant(BLUE.into()),
                 scale: (10.0..0.1).into(),
                 rotation_speed: 2.0.into(),
                 ..ParticleSystem::default()
@@ -146,9 +147,9 @@ fn startup_system(mut commands: Commands, asset_server: Res<AssetServer>) {
                 lifetime: JitteredValue::jittered(1.5, -0.2..0.2),
                 color: ColorOverTime::Gradient(Curve::new(vec![
                     CurvePoint::new(Color::WHITE, 0.0),
-                    CurvePoint::new(Color::rgba(0.8, 0.2, 0.0, 1.0), 0.05),
-                    CurvePoint::new(Color::rgba(0.0, 0.0, 0.0, 0.25), 0.5),
-                    CurvePoint::new(Color::rgba(0.0, 0.0, 0.0, 0.0), 1.0),
+                    CurvePoint::new(Color::srgba(0.8, 0.2, 0.0, 1.0), 0.05),
+                    CurvePoint::new(Color::srgba(0.0, 0.0, 0.0, 0.25), 0.5),
+                    CurvePoint::new(Color::srgba(0.0, 0.0, 0.0, 0.0), 1.0),
                 ])),
                 scale: (8.0..50.0).into(),
                 rotation_speed: 2.0.into(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,10 +67,10 @@ use bevy_app::{
     prelude::{App, Plugin},
     Update,
 };
+use bevy_color::prelude::Color;
 use bevy_ecs::prelude::IntoSystemConfigs;
 use bevy_math::Vec3;
 use bevy_reflect::std_traits::ReflectDefault;
-use bevy_render::color::Color;
 pub use components::*;
 pub use systems::ParticleSystemSet;
 use systems::{

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -1,8 +1,7 @@
 use bevy_ecs::prelude::{Commands, Entity, Query, Res, SystemSet, With};
 use bevy_hierarchy::BuildChildren;
 use bevy_math::{Quat, Vec2, Vec3};
-use bevy_sprite::prelude::{Sprite, SpriteBundle};
-use bevy_sprite::{SpriteSheetBundle, TextureAtlas};
+use bevy_sprite::prelude::{Sprite, SpriteBundle, TextureAtlas};
 use bevy_time::{Real, Time};
 use bevy_transform::prelude::{GlobalTransform, Transform};
 
@@ -192,20 +191,23 @@ pub fn particle_spawner(
                             atlas: atlas_handle,
                             index,
                         } => {
-                            entity_commands.insert(SpriteSheetBundle {
-                                texture: texture_handle.clone(),
-                                sprite: Sprite {
-                                    color: particle_system.color.at_lifetime_pct(0.0),
-                                    custom_size: particle_system.rescale_texture,
-                                    ..Sprite::default()
+                            entity_commands.insert((
+                                SpriteBundle {
+                                    texture: texture_handle.clone(),
+                                    sprite: Sprite {
+                                        color: particle_system.color.at_lifetime_pct(0.0),
+                                        custom_size: particle_system.rescale_texture,
+                                        ..Sprite::default()
+                                    },
+
+                                    transform: spawn_point,
+                                    ..SpriteBundle::default()
                                 },
-                                atlas: TextureAtlas {
+                                TextureAtlas {
                                     layout: atlas_handle.clone(),
                                     index: index.get_value(&mut rng),
                                 },
-                                transform: spawn_point,
-                                ..SpriteSheetBundle::default()
-                            });
+                            ));
 
                             if let AtlasIndex::Animated(animated_index) = index {
                                 entity_commands.insert(animated_index.clone());
@@ -257,20 +259,22 @@ pub fn particle_spawner(
                                 atlas: atlas_handle,
                                 index,
                             } => {
-                                entity_commands.insert(SpriteSheetBundle {
-                                    texture: texture_handle.clone(),
-                                    sprite: Sprite {
-                                        color: particle_system.color.at_lifetime_pct(0.0),
-                                        custom_size: particle_system.rescale_texture,
-                                        ..Sprite::default()
+                                entity_commands.insert((
+                                    SpriteBundle {
+                                        texture: texture_handle.clone(),
+                                        sprite: Sprite {
+                                            color: particle_system.color.at_lifetime_pct(0.0),
+                                            custom_size: particle_system.rescale_texture,
+                                            ..Sprite::default()
+                                        },
+                                        transform: spawn_point,
+                                        ..SpriteBundle::default()
                                     },
-                                    atlas: TextureAtlas {
+                                    TextureAtlas {
                                         layout: atlas_handle.clone(),
                                         index: index.get_value(&mut rng),
                                     },
-                                    transform: spawn_point,
-                                    ..SpriteSheetBundle::default()
-                                });
+                                ));
 
                                 if let AtlasIndex::Animated(animated_index) = index {
                                     entity_commands.insert(animated_index.clone());

--- a/src/values.rs
+++ b/src/values.rs
@@ -1,10 +1,11 @@
 //! Different value types and controls used in particle systems.
 use std::ops::Range;
 
+use bevy_color::prelude::Color;
+use bevy_color::Srgba;
 use bevy_math::{vec3, Quat, Vec2, Vec3};
 use bevy_reflect::std_traits::ReflectDefault;
 use bevy_reflect::{FromReflect, Reflect};
-use bevy_render::prelude::Color;
 use bevy_transform::prelude::Transform;
 use rand::seq::SliceRandom;
 use rand::{prelude::ThreadRng, Rng};
@@ -475,14 +476,14 @@ impl Lerpable<Color> for Color {
         // copies the entire struct every time, whereas this should only copy once each.
         // This whas showing up in the hot path when profiling the `basic` example when
         // calling each individually, due to the excessive copies.
-        let rgba = self.as_rgba_f32();
-        let other_rgba = other.as_rgba_f32();
+        let rgba = Srgba::from(*self);
+        let other_rgba = Srgba::from(other);
 
-        Color::rgba(
-            rgba[0].lerp(other_rgba[0], clamped_pct),
-            rgba[1].lerp(other_rgba[1], clamped_pct),
-            rgba[2].lerp(other_rgba[2], clamped_pct),
-            rgba[3].lerp(other_rgba[3], clamped_pct),
+        Color::srgba(
+            rgba.red.lerp(other_rgba.red, clamped_pct),
+            rgba.green.lerp(other_rgba.green, clamped_pct),
+            rgba.blue.lerp(other_rgba.blue, clamped_pct),
+            rgba.alpha.lerp(other_rgba.alpha, clamped_pct),
         )
     }
 }
@@ -515,7 +516,7 @@ impl ErrorDefault<Vec3> for Vec3 {
 
 impl ErrorDefault<Color> for Color {
     fn get_error_default() -> Color {
-        Color::FUCHSIA
+        bevy_color::palettes::css::FUCHSIA.into()
     }
 }
 


### PR DESCRIPTION
- Updated the version requirement for all `bevy` crates to 0.14.
- Added `bevy_color` as a dependency.
- Updated library code and examples to work with 0.14 changes.

TODO:
- [x] The compatibility table in README.md should be updated with the proper version of the crate that will support bevy 0.14.
- [ ] Check that there are no regressions in the examples.
- [ ] Since `SpriteSheetBundle` was deprecated we could refactor `ParticleTexture` to make it simpler (thus containing two breaking changes in a single release).