### PR TITLE
Refactor `particle_spawner` system

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@ pub use components::*;
 pub use systems::ParticleSystemSet;
 use systems::{
     particle_cleanup, particle_lifetime, particle_spawner, particle_sprite_color,
-    particle_texture_atlas_color, particle_transform,
+    particle_texture_atlas_index, particle_transform,
 };
 pub use values::*;
 
@@ -107,7 +107,7 @@ impl Plugin for ParticleSystemPlugin {
                 particle_spawner,
                 particle_lifetime,
                 particle_sprite_color,
-                particle_texture_atlas_color,
+                particle_texture_atlas_index,
                 particle_transform,
                 particle_cleanup,
             )

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -147,31 +147,33 @@ pub fn particle_spawner(
                     Quat::from_rotation_z(particle_system.initial_rotation.get_value(&mut rng));
             };
 
+            let particle_bundle = ParticleBundle {
+                particle: Particle {
+                    parent_system: entity,
+                    max_lifetime: particle_system.lifetime.get_value(&mut rng),
+                    max_distance: particle_system.max_distance,
+                    use_scaled_time: particle_system.use_scaled_time,
+                    initial_scale,
+                    scale: particle_system.scale.clone(),
+                    rotation_speed: particle_system.rotation_speed.get_value(&mut rng),
+                    velocity_modifiers: particle_system.velocity_modifiers.clone(),
+                    despawn_with_parent: particle_system.despawn_particles_with_system,
+                },
+                velocity: Velocity::new(
+                    direction * particle_system.initial_speed.get_value(&mut rng),
+                    true,
+                ),
+                distance: DistanceTraveled {
+                    dist_squared: 0.0,
+                    from: spawn_point.translation,
+                },
+                color: ParticleColor(particle_system.color.clone()),
+                ..ParticleBundle::default()
+            };
+
             match particle_system.space {
                 ParticleSpace::World => {
-                    let mut entity_commands = commands.spawn(ParticleBundle {
-                        particle: Particle {
-                            parent_system: entity,
-                            max_lifetime: particle_system.lifetime.get_value(&mut rng),
-                            max_distance: particle_system.max_distance,
-                            use_scaled_time: particle_system.use_scaled_time,
-                            initial_scale,
-                            scale: particle_system.scale.clone(),
-                            rotation_speed: particle_system.rotation_speed.get_value(&mut rng),
-                            velocity_modifiers: particle_system.velocity_modifiers.clone(),
-                            despawn_with_parent: particle_system.despawn_particles_with_system,
-                        },
-                        velocity: Velocity::new(
-                            direction * particle_system.initial_speed.get_value(&mut rng),
-                            true,
-                        ),
-                        distance: DistanceTraveled {
-                            dist_squared: 0.0,
-                            from: spawn_point.translation,
-                        },
-                        color: ParticleColor(particle_system.color.clone()),
-                        ..ParticleBundle::default()
-                    });
+                    let mut entity_commands = commands.spawn(particle_bundle);
 
                     match &particle_system.texture {
                         ParticleTexture::Sprite(image_handle) => {
@@ -217,29 +219,7 @@ pub fn particle_spawner(
                 }
                 ParticleSpace::Local => {
                     commands.entity(entity).with_children(|parent| {
-                        let mut entity_commands = parent.spawn(ParticleBundle {
-                            particle: Particle {
-                                parent_system: entity,
-                                max_lifetime: particle_system.lifetime.get_value(&mut rng),
-                                max_distance: particle_system.max_distance,
-                                use_scaled_time: particle_system.use_scaled_time,
-                                initial_scale,
-                                scale: particle_system.scale.clone(),
-                                rotation_speed: particle_system.rotation_speed.get_value(&mut rng),
-                                velocity_modifiers: particle_system.velocity_modifiers.clone(),
-                                despawn_with_parent: particle_system.despawn_particles_with_system,
-                            },
-                            velocity: Velocity::new(
-                                direction * particle_system.initial_speed.get_value(&mut rng),
-                                true,
-                            ),
-                            distance: DistanceTraveled {
-                                dist_squared: 0.0,
-                                from: spawn_point.translation,
-                            },
-                            color: ParticleColor(particle_system.color.clone()),
-                            ..ParticleBundle::default()
-                        });
+                        let mut entity_commands = parent.spawn(particle_bundle);
 
                         match &particle_system.texture {
                             ParticleTexture::Sprite(image_handle) => {

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -300,7 +300,7 @@ pub(crate) fn particle_transform(
                 (raw_time.delta_seconds(), raw_time.elapsed_seconds_wrapped())
             };
 
-            // inititalize precalculated values
+            // initialize precalculated values
             let mut ppv = PrecalculatedParticleVariables::new();
 
             // Apply velocity modifiers to velocity

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -322,30 +322,16 @@ pub(crate) fn particle_sprite_color(
     );
 }
 
-pub(crate) fn particle_texture_atlas_color(
-    mut particle_query: Query<(
-        &Particle,
-        &mut ParticleColor,
-        &Lifetime,
-        &mut Sprite,
-        &mut TextureAtlas,
-        Option<&AnimatedIndex>,
-    )>,
+pub(crate) fn particle_texture_atlas_index(
+    mut particle_query: Query<(&Lifetime, &mut TextureAtlas, Option<&AnimatedIndex>)>,
 ) {
-    particle_query.par_iter_mut().for_each(
-        |(particle, mut particle_color, lifetime, mut sprite, mut texture_atlas, anim_index)| {
-            let pct = lifetime.0 / particle.max_lifetime;
-            sprite.color = match &mut particle_color.0 {
-                ColorOverTime::Constant(color) => *color,
-                ColorOverTime::Lerp(lerp) => lerp.a.lerp(lerp.b, pct),
-                ColorOverTime::Gradient(curve) => curve.sample_mut(pct),
-            };
-
+    particle_query
+        .par_iter_mut()
+        .for_each(|(lifetime, mut texture_atlas, anim_index)| {
             if let Some(anim_index) = anim_index {
                 texture_atlas.index = anim_index.get_at_time(lifetime.0);
             }
-        },
-    );
+        });
 }
 
 pub(crate) fn particle_transform(


### PR DESCRIPTION
- Removed some redundant code from a system that was setting both the color of the sprite and the index of the texture atlas, which is no longer necessary after `SpriteSheetBundle` was deprecated. `TextureAtlas` and `Sprite` components are now independent so we can update `Sprite` on one system and the `TextureAtlas` index on the other.
- Refactored `particle_spawner` code to reduce duplication. It should be now clearer that the difference between `ParticleSpace` lies in how the entity hierarchy is built. I feel like this could be simplified a bit more, but I didn't bother fighting against multiple mut borrow issues of `Commands` right now.
- Fixed a small typo in a comment.